### PR TITLE
fix(ios): repair main build break from df5a645

### DIFF
--- a/02_GIGI_APP/GIGI/GigiDebugLogger.swift
+++ b/02_GIGI_APP/GIGI/GigiDebugLogger.swift
@@ -29,7 +29,7 @@ class GigiDebugLogger {
 
     static func voiceEvent(
         _ name: String,
-        turnId: String? = nil,
+        _ turnId: String? = nil,
         _ data: [String: String] = [:],
         location: String = #file,
         function: String = #function,

--- a/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
+++ b/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
@@ -414,6 +414,29 @@ class GigiSmartOrchestrator: ObservableObject {
         Task { await GigiLiveActivityController.shared.endImmediately() }
     }
 
+    // MARK: - Voice turn lifecycle
+
+    // Idempotent: callers (transcript, quickTalk, wakeOrTap, interrupt) just want a
+    // non-nil turnId without caring whether one is already in flight. A barge-in keeps
+    // the existing turn so structured logs (`orchestrator.interruptAndListen`) continue
+    // the same trace; first call after `fireDone` clears `currentVoiceTurnId` allocates
+    // a fresh one.
+    @discardableResult
+    private func ensureVoiceTurn(reason: String) -> String {
+        if let existing = currentVoiceTurnId { return existing }
+        let id = UUID().uuidString.prefix(8).description
+        currentVoiceTurnId = id
+        GigiDebugLogger.voiceEvent("orchestrator.turnStart", id, ["reason": reason])
+        return id
+    }
+
+    private func clearPendingDone(reason: String) {
+        GigiDebugLogger.voiceEvent("orchestrator.clearPendingDone", currentVoiceTurnId, ["reason": reason])
+        pendingDoneMessage = nil
+        doneSafetyTask?.cancel()
+        doneSafetyTask = nil
+    }
+
     // MARK: - Helpers
 
     /// Splits a text containing multiple sequential commands into individual parts.


### PR DESCRIPTION
Closes #81

## What
Repairs the main build break introduced by `df5a645` (saga wake-word/LiveActivity/orchestrator).

Two latent issues that surfaced together when running `xcodebuild`:

1. **`voiceEvent` signature drift** — `GigiDebugLogger.voiceEvent` had its second parameter changed to require label `turnId:`, but all 10 call sites in `GigiAudioManager.swift` + `GigiSmartOrchestrator.swift` pass it positionally. Caused cascading "missing argument labels" + "cannot convert `[String: String]?` to `String`" errors. Fix: drop the label (`_ turnId:`).

2. **Undefined symbols `ensureVoiceTurn` / `clearPendingDone`** — `df5a645` added 5 call sites of these private helpers but never committed the definitions (`git log -S` across all branches confirms they never existed). Probable cause: resolution conflict during commit assembly. Recovered semantics from call site context:
   - `ensureVoiceTurn(reason:) -> String` — idempotent: returns existing `currentVoiceTurnId` or allocates a fresh 8-char UUID prefix; logs `orchestrator.turnStart` only on allocation
   - `clearPendingDone(reason:)` — cancels `doneSafetyTask`, clears `pendingDoneMessage`, logs `orchestrator.clearPendingDone`

`interruptAndListen` is the only call site that overlaps both helpers — it reuses an in-flight turn (rather than allocating fresh) so structured logs (`orchestrator.interruptAndListen`) continue the same trace through a barge-in.

## Why
Main has been broken since `df5a645` (2026-04-26). 20 commits later nobody fixed → blocked **#9** (DI descend on wake) + every iOS dev with a build verify. Launch deadline 2026-05-01.

## Test plan
- [x] `xcodebuild -project GIGI.xcodeproj -scheme GIGI -configuration Debug -destination 'generic/platform=iOS' -allowProvisioningUpdates build` → **BUILD SUCCEEDED** (zero `error:`, only pre-existing actor-isolation warnings unrelated to this PR)
- [x] Cold-launch app on PeterPan_Iphone (iPhone 14) → no crash
- [x] Wake word "hey gigi" → app transitions to listening (no turn-state regression)
- [x] `GigiDebugLogger.voiceEvent(...)` calls produce structured logs with `turnId=...` field

## Files changed
- `02_GIGI_APP/GIGI/GigiDebugLogger.swift` (+1/−1)
- `02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift` (+23/−0)

cc @ArmandoBattaglino — sblocca #9 stand-by + ogni iOS task settimana lancio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)