### PR TITLE
fix(ios): restore missing voice turn helpers + voiceEvent labels (#95)

### DIFF
--- a/02_GIGI_APP/GIGI/GigiAudioManager.swift
+++ b/02_GIGI_APP/GIGI/GigiAudioManager.swift
@@ -155,7 +155,7 @@ final class GigiAudioManager: ObservableObject {
         if suppressNextSpeakingFinished {
             suppressNextSpeakingFinished = false
             if state == .speaking { transition(to: .idle) }
-            GigiDebugLogger.voiceEvent("audio.speakingFinishSuppressed", nil, dataForTrace())
+            GigiDebugLogger.voiceEvent("audio.speakingFinishSuppressed", turnId: nil, dataForTrace())
             print("GigiAudioManager: speaking finish suppressed for barge-in")
             return
         }
@@ -187,14 +187,14 @@ final class GigiAudioManager: ObservableObject {
 
     private func scheduleFollowUpTimeout() {
         followUpTimeoutTask?.cancel()
-        GigiDebugLogger.voiceEvent("audio.followUpWindowStarted", nil, dataForTrace())
+        GigiDebugLogger.voiceEvent("audio.followUpWindowStarted", turnId: nil, dataForTrace())
         followUpTimeoutTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(Self.presenceFollowUpWindow * 1_000_000_000))
             guard !Task.isCancelled, let self else { return }
             // User actually spoke → VAD fired → state already moved off .recording. No-op.
             guard self.state == .recording else { return }
             print("GigiAudioManager: presence follow-up window elapsed — back to wake-word standby")
-            GigiDebugLogger.voiceEvent("audio.followUpWindowElapsed", nil, self.dataForTrace())
+            GigiDebugLogger.voiceEvent("audio.followUpWindowElapsed", turnId: nil, self.dataForTrace())
             self.stopRecording()
             self.resumeWakeWordIfEnabled()
         }
@@ -211,7 +211,7 @@ final class GigiAudioManager: ObservableObject {
 
     private func transition(to newState: GigiAudioState) {
         print("GigiAudioManager: \(state) → \(newState)")
-        GigiDebugLogger.voiceEvent("audio.transition", nil, ["from": "\(state)", "to": "\(newState)", "presenceMode": "\(presenceMode)"])
+        GigiDebugLogger.voiceEvent("audio.transition", turnId: nil, ["from": "\(state)", "to": "\(newState)", "presenceMode": "\(presenceMode)"])
         // Any transition out of .recording invalidates the Presence follow-up window.
         if state == .recording, newState != .recording {
             followUpTimeoutTask?.cancel()
@@ -241,7 +241,7 @@ final class GigiAudioManager: ObservableObject {
 
     private func resumeWakeWordIfEnabled() {
         print("GigiAudioManager: resumeWakeWordIfEnabled — presence=\(presenceMode)")
-        GigiDebugLogger.voiceEvent("audio.resumeWakeWordIfEnabled", nil, dataForTrace())
+        GigiDebugLogger.voiceEvent("audio.resumeWakeWordIfEnabled", turnId: nil, dataForTrace())
         if presenceMode { startWakeWordListening() }
     }
 

--- a/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
+++ b/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
@@ -154,14 +154,14 @@ class GigiSmartOrchestrator: ObservableObject {
         stopMicCapture()
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
-            GigiDebugLogger.voiceEvent("orchestrator.emptyTranscript", currentVoiceTurnId)
+            GigiDebugLogger.voiceEvent("orchestrator.emptyTranscript", turnId: currentVoiceTurnId)
             isThinking = false
             currentVoiceTurnId = nil
             return
         }
 
         let turnId = ensureVoiceTurn(reason: "transcript")
-        GigiDebugLogger.voiceEvent("orchestrator.transcript", turnId, ["length": "\(trimmed.count)"])
+        GigiDebugLogger.voiceEvent("orchestrator.transcript", turnId: turnId, ["length": "\(trimmed.count)"])
 
         await GigiLiveActivityController.shared.transitionToThinking(transcript: trimmed)
         status = "GIGI: Sto pensando..."
@@ -248,7 +248,7 @@ class GigiSmartOrchestrator: ObservableObject {
     // MARK: - Deferred turn close (T4)
 
     private func scheduleDoneAfterTTS(message: String) {
-        GigiDebugLogger.voiceEvent("orchestrator.scheduleDoneAfterTTS", currentVoiceTurnId)
+        GigiDebugLogger.voiceEvent("orchestrator.scheduleDoneAfterTTS", turnId: currentVoiceTurnId)
         pendingDoneMessage = message
         doneSafetyTask?.cancel()
         // Safety: if AVSpeechSynthesizer never reports finish (cancel storms, hardware
@@ -262,7 +262,7 @@ class GigiSmartOrchestrator: ObservableObject {
 
     private func fireDone() {
         guard let msg = pendingDoneMessage else { return }
-        GigiDebugLogger.voiceEvent("orchestrator.fireDone", currentVoiceTurnId)
+        GigiDebugLogger.voiceEvent("orchestrator.fireDone", turnId: currentVoiceTurnId)
         pendingDoneMessage = nil
         doneSafetyTask?.cancel()
         doneSafetyTask = nil
@@ -271,7 +271,7 @@ class GigiSmartOrchestrator: ObservableObject {
     }
 
     private func finalizeTurnNow(message: String) {
-        GigiDebugLogger.voiceEvent("orchestrator.finalizeTurn", currentVoiceTurnId, ["presenceMode": "\(GigiAudioManager.shared.presenceMode)", "quickTalk": "\(isQuickTalkSession)"])
+        GigiDebugLogger.voiceEvent("orchestrator.finalizeTurn", turnId: currentVoiceTurnId, ["presenceMode": "\(GigiAudioManager.shared.presenceMode)", "quickTalk": "\(isQuickTalkSession)"])
         SoundEngine.releaseSession()
 
         if isQuickTalkSession {
@@ -383,7 +383,7 @@ class GigiSmartOrchestrator: ObservableObject {
     func interruptAndListen(source: String) {
         let turnId = ensureVoiceTurn(reason: "interrupt.\(source)")
         clearPendingDone(reason: "bargeIn.\(source)")
-        GigiDebugLogger.voiceEvent("orchestrator.interruptAndListen", turnId, ["source": source, "audioState": "\(GigiAudioManager.shared.state)"])
+        GigiDebugLogger.voiceEvent("orchestrator.interruptAndListen", turnId: turnId, ["source": source, "audioState": "\(GigiAudioManager.shared.state)"])
 
         SoundEngine.play(.wakeWord)
         if isQuickTalkSession { onQuickTalkStateChange?(.listening) }
@@ -459,5 +459,35 @@ class GigiSmartOrchestrator: ObservableObject {
         }
 
         return validParts.count >= 2 ? validParts : nil
+    }
+
+    // MARK: - Voice turn lifecycle helpers
+    //
+    // Reconstructed from call-site contracts after #95 (ensureVoiceTurn /
+    // clearPendingDone were referenced by `df5a645` but their definitions
+    // were never committed). Behaviour kept conservative: log + minimal
+    // state mutation, no impact on existing turn flow.
+
+    /// Returns the current voice turn id, generating a new one if none is active.
+    /// `reason` is a short tag describing the trigger (transcript / wake / interrupt / quickTalk).
+    @discardableResult
+    fileprivate func ensureVoiceTurn(reason: String) -> String {
+        if let existing = currentVoiceTurnId {
+            GigiDebugLogger.voiceEvent("orchestrator.ensureVoiceTurn.reuse", turnId: existing, ["reason": reason])
+            return existing
+        }
+        let newId = String(UUID().uuidString.prefix(8))
+        currentVoiceTurnId = newId
+        GigiDebugLogger.voiceEvent("orchestrator.ensureVoiceTurn.new", turnId: newId, ["reason": reason])
+        return newId
+    }
+
+    /// Cancels any pending deferred-done state (used on barge-in / interrupt).
+    fileprivate func clearPendingDone(reason: String) {
+        guard pendingDoneMessage != nil || doneSafetyTask != nil else { return }
+        GigiDebugLogger.voiceEvent("orchestrator.clearPendingDone", turnId: currentVoiceTurnId, ["reason": reason])
+        pendingDoneMessage = nil
+        doneSafetyTask?.cancel()
+        doneSafetyTask = nil
     }
 }


### PR DESCRIPTION
Closes #95

## What
Restores the build on `main`:
1. Adds `ensureVoiceTurn(reason:)` and `clearPendingDone(reason:)` to `GigiSmartOrchestrator`. These were called from 5 sites in `df5a645` ("saga del wake-word") but their definitions were never committed.
2. Fixes 11 `GigiDebugLogger.voiceEvent` calls (5 in `GigiAudioManager`, 6 in `GigiSmartOrchestrator`) that passed positional `nil` / `String?` where the signature requires the `turnId:` label.

## Why
`xcodebuild` on `main` fails with 14+ errors → every feature branch (#60, #50/51/52, #61-63, etc.) is blocked from build verify, four days before code freeze.

## Reconstructed behaviour (please review @Leonardo-Corte)

`ensureVoiceTurn(reason:) -> String` returns `currentVoiceTurnId`, generating a fresh 8-char UUID if none active. `clearPendingDone(reason:)` cancels `pendingDoneMessage` + `doneSafetyTask`.

Inferred from call sites: `ensureVoiceTurn` always returns a String (assigned to `let turnId`), called for `transcript` / `quickTalk` / `wakeOrTap` / `interrupt.<source>` reasons. `clearPendingDone` only called inside `interruptAndListen` (barge-in).

If your original implementation differs, push corrections on top.

## Test plan
- [x] xcodebuild Debug build = BUILD SUCCEEDED (verified on Mac, generic/platform=iOS, no codesign)
- [ ] Smoke test on device: wake -> listening -> thinking -> speaking -> done
- [ ] Barge-in: speak while GIGI talking, verify pending-done clears

cc @ArmandoBattaglino @Leonardo-Corte