### PR TITLE
feat(ios): refine TalkToGIGI AppShortcut phrases for system-wide discovery (Refs #102)

### DIFF
--- a/02_GIGI_APP/GIGI/GigiQuickTalkIntent.swift
+++ b/02_GIGI_APP/GIGI/GigiQuickTalkIntent.swift
@@ -3,15 +3,18 @@ import Foundation
 
 // MARK: - GigiQuickTalkIntent
 //
-// AppIntent for Action Button / Shortcuts integration.
-// Brings app to foreground and starts a Quick Talk voice session.
-// Register via GigiAppShortcuts for automatic Shortcuts discovery.
+// AppIntent that opens GIGI and starts a one-shot voice turn. This is the
+// primary entry point for hardware triggers — Action Button on iPhone 15 Pro+,
+// Back Tap on iPhone 14 (Settings → Accessibility → Touch → Back Tap), and the
+// Siri phrases declared in GigiAppShortcuts below. When MVP wake word is
+// disabled (#102), this is the canonical "wake-from-anywhere" path.
 
 @available(iOS 16.0, *)
 struct GigiQuickTalkIntent: AppIntent {
     static var title: LocalizedStringResource = "Talk to GIGI"
-    static var description = IntentDescription("Start a Quick Talk voice session with GIGI")
-    static var openAppWhenRun: Bool = true   // mic requires foreground
+    static var description = IntentDescription("Open GIGI and start a voice turn — the same as a double-tap on the back of your iPhone or pressing the Action Button.")
+    // Mic capture requires foreground; iOS will unlock the device first if locked.
+    static var openAppWhenRun: Bool = true
 
     func perform() async throws -> some IntentResult {
         await MainActor.run {
@@ -22,6 +25,17 @@ struct GigiQuickTalkIntent: AppIntent {
 }
 
 // MARK: - GigiAppShortcuts
+//
+// Declaring AppShortcuts makes "Talk to GIGI" discoverable system-wide:
+//   • Siri picks up the phrases below — no setup required from the user.
+//   • Shortcuts app lists the intent under "GIGI" automatically.
+//   • Settings → Action Button → Shortcut → App Shortcuts → GIGI.
+//   • Settings → Accessibility → Touch → Back Tap → Double Tap → GIGI.
+//   • Spotlight search returns the intent when typing "talk to gigi".
+//
+// Apple requires every phrase to contain \(.applicationName); the substitution
+// resolves to "GIGI", so "Hey \(.applicationName)" reads as "Hey GIGI" — the
+// natural wake phrase, but routed through Siri rather than a continuous mic.
 
 @available(iOS 16.0, *)
 struct GigiAppShortcuts: AppShortcutsProvider {
@@ -29,8 +43,8 @@ struct GigiAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: GigiQuickTalkIntent(),
             phrases: [
+                "Hey \(.applicationName)",
                 "Talk to \(.applicationName)",
-                "Hey GIGI via \(.applicationName)",
                 "Ask \(.applicationName)",
                 "Open \(.applicationName)"
             ],


### PR DESCRIPTION
Refs #102 · Pairs with #103 (Phase A) and the upcoming Phase C onboarding PR.

## What

The `GigiQuickTalkIntent` AppIntent and `GigiAppShortcuts` provider already existed in the codebase, but the registered phrases had two issues that blocked them from serving as the canonical "wake-from-anywhere" path:

1. **Awkward phrase removed.** "Hey GIGI via GIGI" came from `\(.applicationName)` substitution and read poorly. Replaced with the bare "Hey \(.applicationName)" form, which resolves to "Hey GIGI" — the natural wake phrase, routed through Siri instead of a continuous on-device mic.
2. **Discovery surfaces documented.** Once an AppShortcut is declared, iOS automatically exposes the intent across Spotlight, the Shortcuts app, the Action Button picker, and the Back Tap picker — no per-surface registration code is needed. The file comment now states this so future readers don't have to rediscover it.

The intent body is unchanged: `openAppWhenRun = true` brings the app foreground (iOS will prompt unlock if needed), then `QuickTalkController.shared.start()` fires the listening turn.

## Why

Phase A (#103) disables the on-device wake-word engine because iOS does not allow continuous background mic for non-VoIP apps. Hardware triggers replace it: Action Button on iPhone 15 Pro+, Back Tap on iPhone 14, plus Siri phrases. This PR makes those triggers actually work — without it, users who tap the Action Button don't see "Talk to GIGI" in the picker, and "Hey Siri, hey GIGI" doesn't route to us.

## Discovery surfaces unlocked by this change

| Surface | What user sees |
|---|---|
| Spotlight search | "Talk to GIGI" appears when typing the phrase |
| Shortcuts app | Auto-listed under "GIGI" — no setup |
| Settings → Action Button → Shortcut → App Shortcuts → GIGI | "Talk to GIGI" |
| Settings → Accessibility → Touch → Back Tap → Double Tap → App Shortcuts → GIGI | "Talk to GIGI" |
| Siri | "Hey GIGI", "Talk to GIGI", "Ask GIGI", "Open GIGI" — all route to the intent |

## Files changed

| File | Δ |
|---|---|
| `GigiQuickTalkIntent.swift` | +20 / -6 (phrases + comments) |

## Test plan

### Build verify (done)
- [x] `xcodebuild -destination 'generic/platform=iOS'` → **BUILD SUCCEEDED**

### Author smoke (Stefano on PeterPan iPhone 14)
- [ ] Install build, lock screen
- [ ] "Hey Siri, hey GIGI" → device unlocks, GIGI opens, listening UI fires
- [ ] Open Settings → Accessibility → Touch → Back Tap → Double Tap → App Shortcuts → GIGI → assign "Talk to GIGI"
- [ ] Lock screen, double-tap back of phone → device unlocks, GIGI opens, listening UI fires
- [ ] Open Shortcuts app → "Talk to GIGI" listed under GIGI app

### Demo prep (Stefano + Armando)
- [ ] Configure Back Tap on demo device
- [ ] Verify Siri phrase recognition with the demo Apple ID

## Out of scope

- Phase C onboarding screens that walk the user through Back Tap / Action Button setup (next PR)
- Demo script #18 scene S2 update from "Hey GIGI" wake to "double-tap back of iPhone"

## Linked
- Refs #102