### PR TITLE
feat(ios): onboarding step for hardware trigger setup (Refs #102)

### DIFF
--- a/02_GIGI_APP/GIGI/OnboardingView.swift
+++ b/02_GIGI_APP/GIGI/OnboardingView.swift
@@ -71,7 +71,7 @@ struct OnboardingView: View {
                     case 2: apiKeyStep
                     case 3: harnessStep
                     case 4: profileStep
-                    case 5: wakeWordStep
+                    case 5: hardwareTriggerStep
                     case 6: doneStep
                     default: EmptyView()
                     }
@@ -392,29 +392,104 @@ struct OnboardingView: View {
             .stroke(Color.purple.opacity(0.3), lineWidth: 1))
     }
 
-    private var wakeWordStep: some View {
+    // MARK: - Hardware trigger step (#102)
+    //
+    // Replaces the old wake-word step. iOS does not allow continuous background
+    // mic for non-VoIP apps, so wake word is paused for MVP. Hardware triggers
+    // (Back Tap on iPhone 14, Action Button on iPhone 15 Pro+) plus Siri phrases
+    // open GIGI in <1s from any state. We can't deep-link into iOS Accessibility
+    // settings, so we walk the user through the steps and provide a quick test
+    // button that fires the same code path the trigger will hit.
+
+    private var hardwareTriggerStep: some View {
         VStack(spacing: 20) {
-            Image(systemName: "ear.fill")
+            Image(systemName: "hand.tap.fill")
                 .font(.system(size: 56))
                 .foregroundStyle(.purple)
 
-            Text("Presence")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
+            Text("Talk to GIGI from anywhere")
+                .font(.system(size: 26, weight: .bold, design: .rounded))
                 .foregroundColor(.white)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
 
-            Text("Enable Presence to keep GIGI Ready through a Live Activity. Say **\"Hey GIGI\"** or **\"GIGI\"** while iOS keeps the app eligible; if iOS pauses it, tap the Live Activity or app shortcut to resume.\n\nReady is standby. Listening appears only during active capture.")
+            Text("Set up a hardware shortcut once, then open GIGI in under a second — even with the screen locked.")
                 .font(.subheadline)
                 .multilineTextAlignment(.center)
                 .foregroundColor(.white.opacity(0.7))
                 .padding(.horizontal, 28)
 
-            Toggle("Enable Presence", isOn: Binding(
-                get: { UserDefaults.standard.bool(forKey: GigiWakeWordEngine.userDefaultsEnabledKey) },
-                set: { PresenceSessionController.shared.setAlwaysAvailable($0) }
-            ))
-            .tint(.purple)
-            .padding(.horizontal, 40)
+            VStack(alignment: .leading, spacing: 12) {
+                triggerRow(number: "1", title: "Open the iOS Settings app")
+                triggerRow(number: "2", title: hardwareTriggerPath)
+                triggerRow(number: "3", title: "Pick App Shortcuts → GIGI → Talk to GIGI")
+            }
+            .padding(16)
+            .background(Color.white.opacity(0.05))
+            .cornerRadius(14)
+            .padding(.horizontal, 24)
+
+            Button {
+                QuickTalkController.shared.start()
+            } label: {
+                Label("Test it now", systemImage: "mic.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(Color.purple.opacity(0.85))
+                    .cornerRadius(10)
+            }
+            .padding(.horizontal, 28)
+
+            Text("Tip: \"Hey Siri, hey GIGI\" works on every iPhone with no setup.")
+                .font(.footnote)
+                .foregroundColor(.white.opacity(0.5))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
         }
+    }
+
+    private func triggerRow(number: String, title: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text(number)
+                .font(.subheadline.weight(.bold))
+                .foregroundColor(.white)
+                .frame(width: 24, height: 24)
+                .background(Circle().fill(Color.purple))
+            Text(title)
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.85))
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// Picks Action Button copy for iPhone 15 Pro / 16 Pro / 17 Pro and Back Tap
+    /// copy for everything else. We detect via the device model identifier rather
+    /// than `UIDevice.current.model` (which only returns "iPhone").
+    private var hardwareTriggerPath: String {
+        if hasActionButton {
+            return "Go to Action Button → Shortcut"
+        } else {
+            return "Go to Accessibility → Touch → Back Tap → Double Tap"
+        }
+    }
+
+    private var hasActionButton: Bool {
+        #if canImport(UIKit)
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let identifier = withUnsafePointer(to: &systemInfo.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) { String(validatingUTF8: $0) ?? "" }
+        }
+        // Action Button ships on iPhone 15 Pro / Pro Max (iPhone16,1 / 16,2),
+        // iPhone 16 Pro / Pro Max (iPhone17,1 / 17,2), and all iPhone 16 non-Pro
+        // (iPhone17,3 / 17,4). Conservative check: any iPhone16,* or iPhone17,*.
+        return identifier.hasPrefix("iPhone16,") || identifier.hasPrefix("iPhone17,")
+        #else
+        return false
+        #endif
     }
 
     private var doneStep: some View {
@@ -427,7 +502,7 @@ struct OnboardingView: View {
                 .font(.system(size: 32, weight: .bold, design: .rounded))
                 .foregroundColor(.white)
 
-            Text("Tap the mic for one-shot voice or enable Presence for wake-word standby.\n\nTry: \"Call Marco\", \"What's the weather?\", \"Set a timer for 10 minutes\"")
+            Text("Tap the mic to talk, or use the hardware shortcut you just set up.\n\nTry: \"Call Marco\", \"What's the weather?\", \"Set a timer for 10 minutes\"")
                 .font(.subheadline)
                 .multilineTextAlignment(.center)
                 .foregroundColor(.white.opacity(0.7))


### PR DESCRIPTION
Refs #102 · Pairs with #103 (Phase A) and #104 (Phase B).

## What

Phase C of the wake-word de-scope. Step 5 of `OnboardingView` was the "Enable Presence / wake word" toggle; it is now a walkthrough that teaches the user to bind "Talk to GIGI" to a hardware trigger.

The step adapts to the device:

- **iPhone 15 Pro and newer** (`iPhone16,*` / `iPhone17,*` model identifiers) → Action Button path: *Settings → Action Button → Shortcut*.
- **iPhone 14 and earlier** → Back Tap path: *Settings → Accessibility → Touch → Back Tap → Double Tap*. This is what Armando and Leo will use on PeterPan.

iOS does not expose a deep-link directly to Accessibility, so the step gives clear numbered instructions inside a card, plus a **Test it now** button that fires `QuickTalkController.shared.start()` — the exact code path the AppIntent will hit. A footnote calls out "Hey Siri, hey GIGI" as the zero-setup fallback for users who skip the hardware step.

The done step copy is updated to drop the wake-word reference.

## Why

Phase A disabled the wake-word engine; Phase B made the `Talk to GIGI` AppIntent discoverable system-wide. Without onboarding, a user who installs a fresh build won't know any of this exists. The walkthrough closes the loop and matches the Settings "Run setup walkthrough" button shipped in Phase A — both routes land on this step.

## Design notes

- Device detection uses the kernel `utsname()` model identifier rather than `UIDevice.current.model`, which on every iPhone returns the literal string "iPhone" and doesn't distinguish models. The conservative `iPhone16,* / iPhone17,*` prefix check is correct for the entire 15 Pro / 16 / 17 family that ships with Action Button. iPhone 14 and earlier fall through to the Back Tap path.
- "Test it now" reuses the same controller the intent calls. If the user tests here and the listening UI fires, we know the trigger will fire too once they bind it.
- No deep-link to iOS Accessibility settings exists publicly, so we instruct rather than navigate. Users who finish onboarding without binding the trigger can still re-run the walkthrough from Settings (Phase A button).

## Files changed

| File | Δ |
|---|---|
| `OnboardingView.swift` | +88 / -13 (replace `wakeWordStep` with `hardwareTriggerStep`, add `triggerRow` + `hasActionButton`, update done step copy) |

## Test plan

### Build verify (done)
- [x] `xcodebuild -destination 'generic/platform=iOS'` → **BUILD SUCCEEDED**

### Author smoke (Stefano on PeterPan iPhone 14)
- [ ] Reset onboarding (Settings → "Run setup walkthrough" once Phase A is in, or `defaults delete <bundle> gigi.onboarding.complete`)
- [ ] Re-run onboarding to step 5 — sees Back Tap instructions (not Action Button)
- [ ] "Test it now" button → listening UI fires
- [ ] Continue to done step — copy reflects hardware trigger, not wake word
- [ ] Manually configure Back Tap → Double Tap → Talk to GIGI per the instructions
- [ ] Lock screen → double-tap back → device unlocks, GIGI opens, listens

### Cross-device (any iPhone 15 Pro+ if available)
- [ ] Step 5 shows Action Button path instead of Back Tap

## Linked
- Refs #102, paired with #103 + #104