### PR TITLE
feat(harness): preflight script auto-detect config (Win + Mac + Linux)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Forza LF endings su shell scripts e file POSIX-only.
+# Senza questo, Win Git autocrlf converte a CRLF nel working copy → bash crash con `$'\r'`.
+
+*.sh        text eol=lf
+*.bash      text eol=lf
+start-*.sh  text eol=lf

--- a/03_HARNESS/server/preflight.sh
+++ b/03_HARNESS/server/preflight.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# preflight.sh — verifica setup harness pronto (config.json + .env vs example baseline)
+#
+# Exit codes:
+#   0 = ready (config + env presenti, no missing top-level keys)
+#   1 = missing required top-level keys in config (.env warning non blocca)
+#   2 = file totalmente assente (config.json o .env)
+#
+# Uso: bash 03_HARNESS/server/preflight.sh  (da qualsiasi cwd dentro il repo)
+
+set -uo pipefail
+
+# --- Colori (disabilitabili via NO_COLOR=1) ---
+if [ -n "${NO_COLOR:-}" ] || [ ! -t 1 ]; then
+  C_OK=""; C_WARN=""; C_ERR=""; C_RESET=""
+else
+  C_OK=$'\033[0;32m'; C_WARN=$'\033[0;33m'; C_ERR=$'\033[0;31m'; C_RESET=$'\033[0m'
+fi
+
+log_ok()   { printf "%s[OK]%s   %s\n"   "$C_OK"   "$C_RESET" "$*"; }
+log_warn() { printf "%s[WARN]%s %s\n"   "$C_WARN" "$C_RESET" "$*"; }
+log_err()  { printf "%s[ERR]%s  %s\n"   "$C_ERR"  "$C_RESET" "$*" >&2; }
+
+# --- Server dir = dir dello script stesso (robusto a cwd e worktree multipli) ---
+SERVER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ ! -f "$SERVER_DIR/server.js" ] && [ ! -f "$SERVER_DIR/panel.js" ]; then
+  log_err "$SERVER_DIR doesn't look like the harness server dir (missing server.js / panel.js)."
+  log_err "Move preflight.sh back into 03_HARNESS/server/ or run it from there."
+  exit 2
+fi
+
+# --- OS detect → scegli example baseline ---
+OS_RAW=$(uname -s 2>/dev/null || echo "unknown")
+case "$OS_RAW" in
+  Darwin)
+    OS_LABEL="mac"
+    EXAMPLE_CONFIG="$SERVER_DIR/config.example.mac.json"
+    ;;
+  Linux|MINGW*|MSYS*|CYGWIN*)
+    OS_LABEL="win-or-linux"
+    EXAMPLE_CONFIG="$SERVER_DIR/config.example.json"
+    ;;
+  *)
+    log_warn "Unknown OS '$OS_RAW' — defaulting to config.example.json"
+    OS_LABEL="unknown"
+    EXAMPLE_CONFIG="$SERVER_DIR/config.example.json"
+    ;;
+esac
+
+EXAMPLE_ENV="$SERVER_DIR/.env.example"
+USER_CONFIG="$SERVER_DIR/config.json"
+USER_ENV="$SERVER_DIR/.env"
+
+if [ ! -f "$EXAMPLE_CONFIG" ]; then
+  log_err "Example baseline missing: $EXAMPLE_CONFIG"
+  exit 2
+fi
+
+# --- Estrazione keys ---
+extract_json_top_keys() {
+  local file="$1"
+  local out
+  if command -v jq >/dev/null 2>&1; then
+    out=$(jq -r 'keys[]' "$file" 2>/dev/null)
+    if [ $? -eq 0 ] && [ -n "$out" ]; then
+      echo "$out"
+      return 0
+    fi
+    # jq exists ma è fake/broken o file unparseable → fallback grep
+  fi
+  grep -E '^  "[a-zA-Z_]+"[[:space:]]*:' "$file" | sed -E 's/^  "([a-zA-Z_]+)".*/\1/'
+}
+
+extract_env_keys() {
+  local file="$1"
+  grep -E '^[A-Z_][A-Z0-9_]*=' "$file" | sed -E 's/=.*//'
+}
+
+# --- Header ---
+echo
+echo "GIGI Harness Preflight"
+echo "  OS detected:    $OS_RAW ($OS_LABEL)"
+echo "  Server dir:     $SERVER_DIR"
+echo "  Config example: $(basename "$EXAMPLE_CONFIG")"
+echo "  Env example:    $(basename "$EXAMPLE_ENV")"
+echo
+printf "  %-15s | %-7s | %s\n" "FILE" "EXISTS" "STATUS / MISSING KEYS"
+printf "  %-15s-+-%-7s-+-%s\n" "---------------" "-------" "------------------------------------"
+
+EXIT_CODE=0
+MISSING_FILE=0
+
+# --- config.json check ---
+if [ ! -f "$USER_CONFIG" ]; then
+  printf "  %-15s | %-7s | %s\n" "config.json" "NO" "FILE ABSENT"
+  MISSING_FILE=1
+else
+  required_keys=$(extract_json_top_keys "$EXAMPLE_CONFIG" | sort -u)
+  user_keys=$(extract_json_top_keys "$USER_CONFIG" | sort -u)
+  if [ -z "$user_keys" ]; then
+    printf "  %-15s | %-7s | %s\n" "config.json" "yes" "UNPARSEABLE (invalid JSON?)"
+    EXIT_CODE=1
+  else
+    missing=$(comm -23 <(echo "$required_keys") <(echo "$user_keys") | tr '\n' ',' | sed 's/,$//')
+    if [ -z "$missing" ]; then
+      printf "  %-15s | %-7s | %s\n" "config.json" "yes" "OK"
+    else
+      printf "  %-15s | %-7s | MISSING: %s\n" "config.json" "yes" "$missing"
+      EXIT_CODE=1
+    fi
+  fi
+fi
+
+# --- .env check ---
+if [ ! -f "$USER_ENV" ]; then
+  printf "  %-15s | %-7s | %s\n" ".env" "NO" "FILE ABSENT"
+  MISSING_FILE=1
+else
+  required_env=$(extract_env_keys "$EXAMPLE_ENV" | sort -u)
+  user_env=$(extract_env_keys "$USER_ENV" | sort -u)
+  missing_env=$(comm -23 <(echo "$required_env") <(echo "$user_env") | tr '\n' ',' | sed 's/,$//')
+  if [ -z "$missing_env" ]; then
+    printf "  %-15s | %-7s | %s\n" ".env" "yes" "OK"
+  else
+    printf "  %-15s | %-7s | (warn) override missing: %s\n" ".env" "yes" "$missing_env"
+  fi
+fi
+
+echo
+
+# --- Final verdict ---
+if [ "$MISSING_FILE" -eq 1 ]; then
+  log_err "Preflight FAIL — required file(s) absent."
+  echo
+  echo "  Fix: copy from example and edit values."
+  if [ ! -f "$USER_CONFIG" ]; then
+    echo "    cp \"$EXAMPLE_CONFIG\" \"$USER_CONFIG\""
+  fi
+  if [ ! -f "$USER_ENV" ]; then
+    echo "    cp \"$EXAMPLE_ENV\" \"$USER_ENV\""
+  fi
+  exit 2
+fi
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+  log_err "Preflight FAIL — config.json missing required top-level keys."
+  echo "  Fix: add the missing keys (compare with $(basename "$EXAMPLE_CONFIG"))."
+  exit 1
+fi
+
+log_ok "Preflight READY — config + env present and complete."
+exit 0

--- a/docs/plans/harness-preflight-script-2026-04-28.md
+++ b/docs/plans/harness-preflight-script-2026-04-28.md
@@ -1,0 +1,120 @@
+# Plan — Harness preflight script (auto-detect config)
+
+> Status: draft, ready for sanity checks
+> Owner: @ArmandoBattaglino (PM, in tandem con Claude)
+> Created: 2026-04-28
+> Triggered by: #64 (QA setup) bloccata 30 min cercando config sparsi tra `Desktop/Harness/telegram-bridge/`, monorepo `03_HARNESS/server/`, e checkpoint folders
+
+## Requirements summary
+
+Durante #64 (QA setup pre-freeze) abbiamo perso 30 min a cercare config harness sparsi. Lo stesso problema bloccherà il QA gate di mercoledì 30 ore 14:45 (parent #17) se non lo risolviamo prima. Serve uno script preflight che:
+
+- Sa dove cercare config su Win + Mac + Linux
+- Diffa con gli example per dire cosa manca
+- Restituisce exit code chiaro + tabella leggibile
+- È runnable in <10s da chiunque cloni il repo
+
+## Scope (deciso 2026-04-28 con PM)
+
+**Single path strategy — mimicare setup-flow attuale del monorepo**
+
+Il setup ufficiale già esistente (vedi `03_HARNESS/server/start-all.sh:13-24`) cerca config in **un solo path**: `03_HARNESS/server/config.json` (override via `HARNESS_CONFIG`). Lo script preflight estende quella stessa logica — non introduce path alternativi (no `Desktop/Harness/telegram-bridge/` standalone, no fallback). Il PM ha confermato che Leo/Fede su Mac hanno setup nello stesso layout monorepo, quindi la single-path strategy copre tutti gli host.
+
+**Cosa fa MVP**:
+- Bash script (`Git Bash` Win + Mac + Linux nativi)
+- OS detect via `uname -s` solo per scegliere quale example usare:
+  - Mac (`Darwin`) → confronta vs `config.example.mac.json`
+  - Win (`MINGW64_NT-*`) / Linux → confronta vs `config.example.json`
+- Verifica `03_HARNESS/server/config.json` + `.env` esistono
+- Diff keys vs example, lista mancanti
+- Tabella + exit code (0 ready / 1 missing / 2 file totalmente assente)
+
+**Fuori scope (PR separato)**:
+- PowerShell version (Git Bash è disponibile su tutte le macchine team)
+- `cloudflared` install detect
+- Hook in `start-harness.sh`
+- Doc runbook
+- Test E2E su Mac di Fede (Fede testa quando installa)
+
+## Acceptance Criteria (MVP)
+
+- [ ] **AC1**: `bash 03_HARNESS/server/preflight.sh` da repo root su Git Bash Win → exit 0 quando config.json + .env presenti e completi vs `config.example.json`
+- [ ] **AC2**: Stesso script su Mac (Darwin) usa `config.example.mac.json` come baseline per il diff
+- [ ] **AC3**: Se `config.json` o `.env` mancante → exit 2 con messaggio "run: cp config.example.json config.json && edit"
+- [ ] **AC4**: Se config presente ma manca una key richiesta → exit 1 con tabella che lista le key mancanti
+- [ ] **AC5**: Output sempre tabella `[file] [exists] [missing keys] [status]`, leggibile in <5s
+- [ ] **AC6**: Verificato sul Win di Armando in Git Bash con 3 scenari (ready / missing key / missing file)
+
+## Implementation steps (MVP)
+
+1. **Read templates** — estraggo lista keys richieste:
+   - `03_HARNESS/server/config.example.json` (Win baseline)
+   - `03_HARNESS/server/config.example.mac.json` (variant Mac, possibile drift)
+   - `03_HARNESS/server/.env.example`
+
+2. **Crea `03_HARNESS/server/preflight.sh`** con:
+   - `set -euo pipefail` + log helper colorati POSIX-compatibili
+   - Risolve repo root via `git rev-parse --show-toplevel` (script gira da qualsiasi cwd dentro il repo)
+   - OS detect via `uname -s` per scegliere example baseline (Darwin → `config.example.mac.json`, altri → `config.example.json`)
+   - Verifica `03_HARNESS/server/config.json` + `.env` esistono — se no exit 2 con suggerimento `cp ...example...`
+   - Diff con example chosen: jq se disponibile, fallback a grep+sed parser POSIX
+   - Output tabella: `[file] [exists] [missing keys] [status]`
+   - Exit 0 ready, 1 missing keys, 2 file assente
+
+3. **Test** sul Win di Armando con 3 scenari:
+   - Setup attuale (config in `Desktop/Harness/`) → trova → exit 0
+   - `mv` config altrove temporaneo → exit 1 con tabella che dice missing
+   - Cancella temporaneamente 1 key in config → exit 1 con tabella key mancante
+
+4. **Commit + PR + merge** dietro normal review
+
+## Files
+
+| File | Azione | Note |
+|---|---|---|
+| `03_HARNESS/server/preflight.sh` | create | core script |
+| `03_HARNESS/server/config.example.json` | read-only | extract required keys |
+| `03_HARNESS/server/config.example.mac.json` | read-only | variant check |
+| `03_HARNESS/server/.env.example` | read-only | extract required env vars |
+
+(Per Full scope, future PR: `preflight.ps1`, `start-harness.sh` hook, `docs/runbooks/harness-preflight.md`)
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `jq` non installato su Git Bash Win | Fallback grep+sed parser POSIX, no jq dependency strict |
+| Config drift tra `config.example.json` (Win) e `config.example.mac.json` (Mac) → false positive | Whitelist keys "platform-specific", warning vs error level |
+| User ha config valido ma in path non listato → false negative | Logga search paths usati + exit code 2 (not 1) per "no config trovato in paths noti" + suggerimento "passa --path X" come futuro |
+| `~/Desktop/...` non porta su Mac (è invece `~/Desktop/...` ok) | Funziona, $HOME è cross-platform |
+| Git Bash riscrive `/c/...` differentemente da PowerShell | Solo bash output, nessun call a tool che espande paths Windows-style |
+
+## Verification (post-implementation)
+
+- [ ] V1: `bash 03_HARNESS/server/preflight.sh` da `GIGI-work/issue-N-...` su Git Bash → exit 0, tabella mostra `Desktop/Harness/telegram-bridge` come source
+- [ ] V2: `mv ~/Desktop/Harness/telegram-bridge/config.json ~/Desktop/Harness/telegram-bridge/config.json.bak && bash preflight.sh` → exit 1, tabella dice "config.json missing"
+- [ ] V3: `git apply` di un patch che rimuove una key dal config → exit 1, tabella dice "missing key: X"
+- [ ] V4: `cp ~/Desktop/Harness/telegram-bridge/{config.json,.env} 03_HARNESS/server/` → preflight prefere monorepo path (priority 1)
+
+## DECISIONE D2 da prendere ora — Worktree
+
+Lo sblocco serve a #64 ma lo script è scope diverso. 2 strategie:
+
+- **D2.A — Stesso worktree**: piggyback su `feat/issue-64-qa-setup`. Pro: 1 PR sola fa unblock end-to-end. Contro: rompe regola workflow "1 issue = 1 branch", il merge bundla tutto.
+- **D2.B — Worktree separato**: `feat/issue-N-harness-preflight`. Pro: clean history. Contro: 2 PR da gestire in serie (preflight prima, poi #64).
+
+**Raccomandazione**: D2.B. Il preflight è general infrastructure, va merged prima e Fede potrà beneficiarne anche per altri lavori.
+
+## Open decisions — sintesi per Armando
+
+1. **D1 — Scope**: MVP oggi only (raccomandato), o Full PR singolo?
+2. **D2 — Worktree**: separato (raccomandato), o piggyback #64?
+
+## Issue da aprire
+
+- Title: `feat(harness): preflight script auto-detect config (Win + Mac + Linux)`
+- Author: ArmandoBattaglino (PM apre direttamente)
+- Assignee: ArmandoBattaglino (lavora con Claude in tandem)
+- Labels: `type:feat`, `area:harness`, `priority:P0`, `release-blocker`, `effort:M`
+- Linked: derives from #64, blocks #17 QA gate (mercoledì 30)
+- Body: usa template feature.md + sezioni 🎯/🔧/✨ + AC sopra + Riferimenti a questo plan


### PR DESCRIPTION
Closes #108

## What
- `03_HARNESS/server/preflight.sh` — bash script che verifica `config.json` + `.env` in `03_HARNESS/server/`, diff top-level keys vs example baseline OS-aware (Darwin → `config.example.mac.json`, altri → `config.example.json`)
- Output tabellare leggibile + exit code: `0` ready, `1` missing key, `2` file assente con suggerimento `cp ...`
- Fallback grep+sed se `jq` non disponibile o broken
- `SERVER_DIR` risolto da `BASH_SOURCE` → worktree-agnostic, gira da qualsiasi cwd
- `.gitattributes` con `*.sh text eol=lf` per evitare crash bash su Win autocrlf
- Plan: `docs/plans/harness-preflight-script-2026-04-28.md`

## Why
Durante #64 (QA setup pre-freeze) abbiamo perso 30 min cercando config sparsi. Stesso problema bloccherà QA gate mercoledì 30 senza un detector cross-platform. Lo script estende la check primitiva esistente in `start-all.sh` con diff schema + suggerimenti azionabili.

## Test plan
Testato live su Git Bash Win 11 (MINGW64_NT-10.0-26200) con 5 scenari:
- [x] **Scenario 1** — Setup vergine (no config.json, no .env) → `EXIT=2` con tabella `FILE ABSENT` + suggerimento `cp config.example.json config.json` esatto
- [x] **Scenario 2** — Setup completo (config.json + .env copiati da example) → `EXIT=0` `Preflight READY`
- [x] **Scenario 3** — Config presente ma top-level key `tunnel` rimossa → `EXIT=1` con tabella `MISSING: tunnel`
- [x] **Scenario 4** — Solo `.env` rimosso → `EXIT=2` con suggerimento mirato `cp .env.example .env` (no copy config superfluo)
- [x] **Scenario 5** — Fallback grep funzionante con jq mascherato (fake stub exit 127): trova le 9 top-level keys, comportamento identico a jq path

## Acceptance criteria (#108)
- [x] AC1 Win Git Bash setup completo → exit 0
- [x] AC2 Mac (Darwin) usa `config.example.mac.json` (verificato via code review case statement, no Mac fisico disponibile)
- [x] AC3 file assente exit 2 + suggerimento cp
- [x] AC4 missing key exit 1 con tabella
- [x] AC5 fallback grep funziona senza jq
- [x] AC6 verificato sul Win del PM (Armando), output approvato

## Out of scope (eventuale PR follow-up)
- PowerShell version (Git Bash è disponibile su tutte le macchine team)
- `cloudflared` install detect + suggerimento install per OS
- Hook in `start-harness.sh` (blocca avvio se preflight fail)
- Doc runbook `docs/runbooks/harness-preflight.md`
- Test E2E su Mac di Fede

## Sblocca
- #64 (QA setup) — può proseguire dal Task 3 una volta che #108 mergiata + PM completa config con valori reali
- #17 QA gate pre-freeze (mercoledì 30 ore 14:45)