### PR TITLE
fix(harness): tunnel race condition at boot — pair endpoint returns 503 until ready

### DIFF
--- a/03_HARNESS/server/api/pair.js
+++ b/03_HARNESS/server/api/pair.js
@@ -18,6 +18,7 @@
 // configured host if no Tailscale interface is present.
 import os from 'node:os';
 import QRCode from 'qrcode';
+import { cloudflared } from '../tunnel/cloudflared-manager.js';
 
 function pickHostIp(cfg) {
   // Tailscale assigns IPv4 in 100.64.0.0/10 (CGNAT range, which Tailscale
@@ -60,23 +61,43 @@ function allowedCorsOrigin(req) {
   return 'http://localhost:7777';
 }
 
+// Returns { ready: bool, url: string|null, reason?: string }.
+// For quick mode we consult the cloudflared singleton (live state) instead of
+// cfg.tunnel.quick.last_url (which is a stale config snapshot — there is a
+// 4-5s race at boot where the config is still null while the QR is generated).
+function resolveTunnelUrl(cfg) {
+  const mode = cfg?.tunnel?.mode || 'manual';
+
+  if (mode === 'named') {
+    const hostname = cfg?.tunnel?.named?.hostname;
+    if (!hostname) return { ready: false, url: null, reason: 'NAMED_HOSTNAME_MISSING' };
+    return { ready: true, url: `https://${hostname}` };
+  }
+
+  if (mode === 'quick') {
+    // Live: prefer the cloudflared subprocess publicUrl over the config snapshot.
+    const live = cloudflared?.publicUrl;
+    if (live) return { ready: true, url: live };
+    const cached = cfg?.tunnel?.quick?.last_url;
+    if (cached) return { ready: true, url: cached };
+    return { ready: false, url: null, reason: 'QUICK_TUNNEL_NOT_READY' };
+  }
+
+  // mode === 'lan' | 'manual' → LAN fallback is intentional, always ready.
+  return { ready: true, url: null }; // url filled by caller via pickHostIp
+}
+
 function buildPayload(cfg) {
   const port = cfg?.server?.port || 7779;
   const mode = cfg?.tunnel?.mode || 'manual';
   const secret = process.env.HARNESS_SHARED_SECRET || cfg?.ios?.shared_secret || '';
 
-  // Mode-aware URL selection:
-  //   named → https://<hostname>   (stable forever, survives reboot)
-  //   quick → https://<last_url>   (trycloudflare, changes on restart)
-  //   lan / manual → http://<local-ip>:<port>
-  let url;
-  if (mode === 'named' && cfg?.tunnel?.named?.hostname) {
-    url = `https://${cfg.tunnel.named.hostname}`;
-  } else if (mode === 'quick' && cfg?.tunnel?.quick?.last_url) {
-    url = cfg.tunnel.quick.last_url;
-  } else {
-    url = `http://${pickHostIp(cfg)}:${port}`;
+  const tunnel = resolveTunnelUrl(cfg);
+  if (!tunnel.ready) {
+    return { _notReady: true, reason: tunnel.reason, mode };
   }
+
+  const url = tunnel.url || `http://${pickHostIp(cfg)}:${port}`;
 
   return {
     url,
@@ -116,6 +137,21 @@ export async function handlePair(req, res, { cfg }) {
   }
 
   const payload = buildPayload(cfg);
+  if (payload._notReady) {
+    sendJson(res, 503, {
+      ok: false,
+      error: {
+        code: 'TUNNEL_NOT_READY',
+        message: payload.reason === 'QUICK_TUNNEL_NOT_READY'
+          ? 'Cloudflare quick tunnel still spinning up — retry in a few seconds.'
+          : payload.reason === 'NAMED_HOSTNAME_MISSING'
+            ? 'Named tunnel mode but cfg.tunnel.named.hostname is not set — run setup wizard.'
+            : 'Tunnel not ready.',
+        mode: payload.mode
+      }
+    });
+    return true;
+  }
   const format  = url.searchParams.get('format');
 
   if (format === 'svg') {

--- a/03_HARNESS/server/panel.js
+++ b/03_HARNESS/server/panel.js
@@ -612,15 +612,49 @@ function getLanIP() {
   return '127.0.0.1';
 }
 
+// Decide the boot label based on the *actual* URL, not the configured mode.
+// Prevents the "URL: 192.168.x.x [quick tunnel]" inconsistency seen when the
+// cloudflared subprocess hadn't spawned yet but mode=quick in the config.
+function tunnelLabelForUrl(urlStr) {
+  if (!urlStr) return ' [LAN only]';
+  try {
+    const u = new URL(urlStr);
+    const host = u.hostname;
+    if (/\.trycloudflare\.com$/i.test(host)) return ' [quick tunnel]';
+    // IPv4 literal or localhost → LAN.
+    if (host === 'localhost' || /^\d{1,3}(\.\d{1,3}){3}$/.test(host)) return ' [LAN only]';
+    // Any other FQDN over HTTPS → named tunnel (or other public CNAME).
+    if (u.protocol === 'https:') return ' [named tunnel]';
+    return ' [LAN only]';
+  } catch {
+    return ' [LAN only]';
+  }
+}
+
 async function printPairingQR() {
-  // Wait for bridge (server.js / port 7779) to be up before printing, so the
-  // QR reflects the correct tunnel URL if one is already active.
+  // Wait for both the bridge AND the tunnel (when mode=quick|named) to be
+  // ready before printing the QR. /api/pair returns 503 with code
+  // TUNNEL_NOT_READY while cloudflared is still spawning — we must not fall
+  // through to the LAN fallback in that window or the QR will encode a LAN
+  // URL that the iPhone can't reach when off-WiFi (issue #113).
   const iosCfgPort = cfg.server?.port || 7779;
-  let bridgeReady = false;
-  for (let i = 0; i < 20; i++) {
+  const tunnelMode = cfg?.tunnel?.mode || 'manual';
+  const requiresTunnel = (tunnelMode === 'quick' || tunnelMode === 'named');
+
+  let payload = null;
+  // Up to 20s polling at 500ms — covers cloudflared cold start (~4-5s typ.)
+  // plus margin for slow links / DNS warmup.
+  for (let i = 0; i < 40; i++) {
     try {
       const r = await fetch(`http://127.0.0.1:${iosCfgPort}/api/pair`, { signal: AbortSignal.timeout(500) });
-      if (r.ok) { bridgeReady = true; break; }
+      if (r.status === 200) {
+        const j = await r.json().catch(() => null);
+        if (j && (j.data || j.url)) {
+          payload = j.data || j;
+          break;
+        }
+      }
+      // 503 TUNNEL_NOT_READY → keep polling. Other non-200 → keep polling too.
     } catch {}
     await new Promise(r => setTimeout(r, 500));
   }
@@ -630,37 +664,25 @@ async function printPairingQR() {
     const require = createRequire(import.meta.url);
     const qrcode = require('qrcode-terminal');
 
-    // Build same JSON payload the web /pair page uses — iOS app decodes JSON.
-    let payload;
-    if (bridgeReady) {
-      // Fetch canonical payload from pair.js (includes tunnel URL if active).
-      try {
-        const r = await fetch(`http://127.0.0.1:${iosCfgPort}/api/pair`, { signal: AbortSignal.timeout(2000) });
-        const j = await r.json();
-        payload = j.data || j;
-      } catch { payload = null; }
+    // If the tunnel never came up and we are in quick|named mode, do NOT
+    // fall back to a LAN-only QR — that would encode an unreachable URL for
+    // off-WiFi clients. Print a clear warning instead.
+    if (!payload && requiresTunnel) {
+      console.warn('[pair] Tunnel non pronto dopo 20s — QR non stampato.');
+      console.warn('[pair] Apri http://localhost:7777/pair quando il tunnel è ready.');
+      return;
     }
 
-    // Fallback: build payload from config directly (LAN IP, no tunnel).
+    // Fallback: only valid for manual / lan modes — encode LAN IP directly.
     if (!payload) {
       const iosCfg = cfg.ios || {};
       const secret = process.env.HARNESS_SHARED_SECRET || iosCfg.shared_secret || '';
-      const mode = cfg?.tunnel?.mode || 'manual';
-      let url;
-      if (mode === 'named' && cfg?.tunnel?.named?.hostname) {
-        url = `https://${cfg.tunnel.named.hostname}`;
-      } else if (mode === 'quick' && cfg?.tunnel?.quick?.last_url) {
-        url = cfg.tunnel.quick.last_url;
-      } else {
-        url = `http://${getLanIP()}:${iosCfgPort}`;
-      }
-      payload = { url, secret, deviceName: os.hostname(), mode, createdAt: new Date().toISOString() };
+      const url = `http://${getLanIP()}:${iosCfgPort}`;
+      payload = { url, secret, deviceName: os.hostname(), mode: tunnelMode, createdAt: new Date().toISOString() };
     }
 
     const qrString = JSON.stringify(payload);
-    const tunnelNote = payload.mode && payload.mode !== 'manual'
-      ? ` [${payload.mode} tunnel]`
-      : ' [LAN only]';
+    const tunnelNote = tunnelLabelForUrl(payload.url);
     console.log('\n── GIGI Pairing QR — scan from iPhone: Settings → Harness → Pair ──');
     qrcode.generate(qrString, { small: true });
     console.log(`URL: ${payload.url}${tunnelNote}`);


### PR DESCRIPTION
Closes #113
Refs #96

## What

Three coordinated fixes to eliminate the boot-time race where the pairing QR could encode the LAN fallback URL while cloudflared was still spinning up:

1. **`pair.js`** — `resolveTunnelUrl()` now consults the live `cloudflared.publicUrl` (singleton state) instead of the stale `cfg.tunnel.quick.last_url` config snapshot. When `mode=quick` and `publicUrl` is `null`, the endpoint returns **HTTP 503** with body `{code: "TUNNEL_NOT_READY", mode: "quick"}` so callers (panel boot QR + future iOS retries) can back off. Same treatment for `mode=named` when hostname is unset.
2. **`panel.js:printPairingQR()`** — extended the polling loop to wait for `/api/pair` to return **HTTP 200** (not just any `.ok` response), up to 20s. On timeout it prints a clear warning instead of falling back to a LAN-only QR — the original bug. The LAN fallback is now only used for `mode === 'manual' || 'lan'`.
3. **Boot label** (`panel.js`) — `[quick tunnel]` / `[named tunnel]` / `[LAN only]` is now derived from the **actual URL** (hostname inspection) instead of `payload.mode`. Fixes the "URL: 192.168.x.x [quick tunnel]" inconsistency.

## Why

Issue #113 (reproduced during #96 PR review): cloudflared takes 4–5 s to spawn at harness boot. During that window:
- The bridge listens on :7779 immediately.
- `cfg.tunnel.quick.last_url` is `null` on a fresh setup, so `pair.js` fell through to the LAN fallback in `pickHostIp()`.
- `printPairingQR()` happily printed a QR encoding `http://192.168.x.x:7779`.
- iPhones scanning from 4G / different WiFi got "Harness unreachable" until a manual retry — when cloudflared finally became ready and the endpoint started returning the public URL.

Now: during the spawn window callers get `503 TUNNEL_NOT_READY`, the panel QR waits up to 20 s for readiness, and the boot label always reflects the URL actually printed.

## Test plan

Tested live on Windows Git Bash (worktree `issue-113-tunnel-race`, cached URL file deleted, `last_url` nulled in config to recreate the original race window):

- [x] **Scenario 1** — bridge up before cloudflared: `curl /api/pair` from 21:53:04 to 21:53:21 returned **HTTP 503 `TUNNEL_NOT_READY`** consistently across ~45 polls (no leaks of the LAN fallback URL).
- [x] **Scenario 2** — after `POST /api/panel/tunnel/restart` and ~7 s wait, `/api/pair` returned **HTTP 200** with `url: https://avi-committee-christ-preparation.trycloudflare.com`.
- [x] **Scenario 3** — boot log inspection: `URL: https://avi-committee-christ-preparation.trycloudflare.com [quick tunnel]`. Unit-style sanity check on `tunnelLabelForUrl()` covers 6 cases (trycloudflare → quick, FQDN HTTPS → named, IPv4 → LAN, localhost → LAN, null → LAN, unknown → LAN), all green.
- [x] **Build verify** — Node-only changes, no syntax errors at runtime, harness boots cleanly in both states.