### PR TITLE
fix(ios): repair main build break introduced by PR #96 squash

### DIFF
--- a/02_GIGI_APP/GIGI/GigiDebugLogger.swift
+++ b/02_GIGI_APP/GIGI/GigiDebugLogger.swift
@@ -29,7 +29,7 @@ class GigiDebugLogger {
 
     static func voiceEvent(
         _ name: String,
-        _ turnId: String? = nil,
+        turnId: String? = nil,
         _ data: [String: String] = [:],
         location: String = #file,
         function: String = #function,

--- a/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
+++ b/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
@@ -426,12 +426,12 @@ class GigiSmartOrchestrator: ObservableObject {
         if let existing = currentVoiceTurnId { return existing }
         let id = UUID().uuidString.prefix(8).description
         currentVoiceTurnId = id
-        GigiDebugLogger.voiceEvent("orchestrator.turnStart", id, ["reason": reason])
+        GigiDebugLogger.voiceEvent("orchestrator.turnStart", turnId: id, ["reason": reason])
         return id
     }
 
     private func clearPendingDone(reason: String) {
-        GigiDebugLogger.voiceEvent("orchestrator.clearPendingDone", currentVoiceTurnId, ["reason": reason])
+        GigiDebugLogger.voiceEvent("orchestrator.clearPendingDone", turnId: currentVoiceTurnId, ["reason": reason])
         pendingDoneMessage = nil
         doneSafetyTask?.cancel()
         doneSafetyTask = nil
@@ -484,33 +484,4 @@ class GigiSmartOrchestrator: ObservableObject {
         return validParts.count >= 2 ? validParts : nil
     }
 
-    // MARK: - Voice turn lifecycle helpers
-    //
-    // Reconstructed from call-site contracts after #95 (ensureVoiceTurn /
-    // clearPendingDone were referenced by `df5a645` but their definitions
-    // were never committed). Behaviour kept conservative: log + minimal
-    // state mutation, no impact on existing turn flow.
-
-    /// Returns the current voice turn id, generating a new one if none is active.
-    /// `reason` is a short tag describing the trigger (transcript / wake / interrupt / quickTalk).
-    @discardableResult
-    fileprivate func ensureVoiceTurn(reason: String) -> String {
-        if let existing = currentVoiceTurnId {
-            GigiDebugLogger.voiceEvent("orchestrator.ensureVoiceTurn.reuse", turnId: existing, ["reason": reason])
-            return existing
-        }
-        let newId = String(UUID().uuidString.prefix(8))
-        currentVoiceTurnId = newId
-        GigiDebugLogger.voiceEvent("orchestrator.ensureVoiceTurn.new", turnId: newId, ["reason": reason])
-        return newId
-    }
-
-    /// Cancels any pending deferred-done state (used on barge-in / interrupt).
-    fileprivate func clearPendingDone(reason: String) {
-        guard pendingDoneMessage != nil || doneSafetyTask != nil else { return }
-        GigiDebugLogger.voiceEvent("orchestrator.clearPendingDone", turnId: currentVoiceTurnId, ["reason": reason])
-        pendingDoneMessage = nil
-        doneSafetyTask?.cancel()
-        doneSafetyTask = nil
-    }
 }


### PR DESCRIPTION
Refs #96

## What
2 commits che ripristinano la build di main dopo che il merge squash di PR #96 ha introdotto 14+ errori:

1. **GigiDebugLogger.swift** (87563ba) — aggiunge la label \`turnId:\` alla signature di \`voiceEvent\`. PR #96 ha cambiato 11 call site usando \`turnId:\` ma non ha incluso questa modifica della signature nel diff
2. **GigiSmartOrchestrator.swift** (7951581) — rimuove le definizioni duplicate \`fileprivate ensureVoiceTurn\`/\`clearPendingDone\` aggiunte da #96 (linee 487-515): le \`private\` originali a riga 425-438 erano già esistenti → "invalid redeclaration". Fixa 2 chiamate positional → labelled

## Why
Main HEAD pre-PR ha 14 errori xcodebuild che bloccano TUTTE le 11 PR aperte. QA gate mercoledì 30 ne dipende.

## Test plan
- [x] xcodebuild Debug build = BUILD SUCCEEDED (verified post-7951581)
- [x] No regression sulle 11 chiamate fixate da #96
- [x] No regression sulle 2 chiamate originali ora labelled coerentemente

## Sblocca
Tutte le 11 PR aperte. Già aggiornate via \`gh pr update-branch\`, ora possono buildare verde.

cc @fc200490-sketch @Leonardo-Corte