### PR TITLE
feat(ios): harness reachability monitor with HarnessStatus state machine (#61)

### DIFF
--- a/02_GIGI_APP/GIGI/GIGIApp.swift
+++ b/02_GIGI_APP/GIGI/GIGIApp.swift
@@ -52,7 +52,8 @@ struct GIGIApp: App {
                     await GigiDebugLogger.flushCrashLogs()
                     GigiDebugLogger.log("flushCrashLogs done")
                     GigiBrainDiagnostics.log()
-                    GigiDebugLogger.log("GigiBrainDiagnostics done")
+                    GigiBrainDiagnostics.shared.startMonitoring()
+                    GigiDebugLogger.log("GigiBrainDiagnostics done — reachability monitor started")
                     // Presence Mode is now the single always-available mode. This starts
                     // Presence only when the user enabled it; otherwise it guarantees the
                     // wake-word engine is off so there is no second parallel logic.

--- a/02_GIGI_APP/GIGI/GigiBrainDiagnostics.swift
+++ b/02_GIGI_APP/GIGI/GigiBrainDiagnostics.swift
@@ -1,6 +1,75 @@
+import Combine
 import Foundation
+import UIKit
 
-enum GigiBrainDiagnostics {
+enum HarnessStatus: String {
+    case online, degraded, offline, unknown
+}
+
+@MainActor
+final class GigiBrainDiagnostics: ObservableObject {
+    static let shared = GigiBrainDiagnostics()
+
+    @Published private(set) var harnessStatus: HarnessStatus = .unknown
+    @Published private(set) var lastSuccessAt: Date?
+    @Published private(set) var consecutiveFailures: Int = 0
+
+    private var monitorTask: Task<Void, Never>?
+
+    private init() {}
+
+    /// Starts a polling loop that pings the harness health endpoint and
+    /// publishes the resulting `HarnessStatus`. Foreground 5s, background 30s.
+    /// Idempotent: a second call cancels and replaces the previous loop.
+    func startMonitoring(
+        foregroundIntervalSec: TimeInterval = 5,
+        backgroundIntervalSec: TimeInterval = 30
+    ) {
+        monitorTask?.cancel()
+        monitorTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.tick()
+                let isBackground = await MainActor.run {
+                    UIApplication.shared.applicationState == .background
+                }
+                let interval = isBackground ? backgroundIntervalSec : foregroundIntervalSec
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+            }
+        }
+    }
+
+    func stopMonitoring() {
+        monitorTask?.cancel()
+        monitorTask = nil
+    }
+
+    private func tick() async {
+        let ok = await GigiHarnessClient.shared.pingHealth()
+        if ok {
+            let wasOffline = harnessStatus == .offline
+            consecutiveFailures = 0
+            lastSuccessAt = Date()
+            harnessStatus = .online
+            if wasOffline {
+                GigiDebugLogger.log("Harness recovery: offline → online")
+            }
+        } else {
+            consecutiveFailures += 1
+            // 1 fail = degraded, 2+ consecutive = offline (≥10s of unreachability with foreground 5s tick)
+            let newStatus: HarnessStatus = consecutiveFailures >= 2 ? .offline : .degraded
+            if harnessStatus != newStatus {
+                GigiDebugLogger.log("Harness status: \(harnessStatus.rawValue) → \(newStatus.rawValue) (consecutiveFailures=\(consecutiveFailures))")
+            }
+            harnessStatus = newStatus
+        }
+    }
+
+    // MARK: - Legacy log shim
+    //
+    // Pre-existing call sites (`GIGIApp.swift`, `SettingsView.swift`) print a
+    // one-shot "Brain Status" banner at app launch. Kept intact to avoid
+    // ripple-edit; new state lives on `harnessStatus` and is observable.
+
     static func log() {
         let apiKey = GigiConfig.groqAPIKey
         let keyStatus: String

--- a/02_GIGI_APP/GIGI/GigiHarnessClient.swift
+++ b/02_GIGI_APP/GIGI/GigiHarnessClient.swift
@@ -456,6 +456,12 @@ final class GigiHarnessClient {
         return await getJSON(path: "/api/ios/health", as: HealthInfo.self, cfg: c)
     }
 
+    /// Boolean wrapper around `health()` for the reachability monitor.
+    func pingHealth() async -> Bool {
+        if case .success = await health() { return true }
+        return false
+    }
+
     // MARK: - Status snapshot (Phase 6C — rich Settings card)
 
     struct StatusSnapshot: Decodable, Equatable {
@@ -493,7 +499,7 @@ final class GigiHarnessClient {
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.httpBody = body
 
-        let backoffs: [UInt64] = [0, 500, 1_000, 2_000]    // ms — primo tentativo senza attesa, poi 0.5s, 1s, 2s
+        let backoffs: [UInt64] = [0, 1_000, 2_000, 4_000]    // ms — exponential 1s/2s/4s per #16 AC
         var lastError: Error = .transport(URLError(.unknown))
 
         for delayMs in backoffs {


### PR DESCRIPTION
Closes #61

## What
Sub 2/4 of #16 (Resilience). Refactors `GigiBrainDiagnostics` from a static-log enum into a `@MainActor ObservableObject` singleton that polls `/api/ios/health` and publishes a `HarnessStatus` (`online` / `degraded` / `offline` / `unknown`) usable as the single source of truth for the rest of the resilience epic.

- `GigiBrainDiagnostics` → `final class ObservableObject` with `@Published harnessStatus`, `lastSuccessAt`, `consecutiveFailures`. Static `log()` kept as backward-compat shim for `GIGIApp` and `SettingsView`.
- `startMonitoring(foregroundIntervalSec: 5, backgroundIntervalSec: 30)` runs a Task loop, switches interval based on `UIApplication.applicationState`.
- Threshold policy (matches AC parent #16): 1 fail = `degraded`, 2+ consecutive = `offline` (≥10s of unreachability with foreground 5s tick), 1 success after offline = automatic recovery to `online`.
- `GigiHarnessClient.pingHealth()` boolean wrapper around `health()`.
- `GigiHarnessClient.sendJSON` retry backoff aligned to `[0, 1s, 2s, 4s]` per #16 AC.
- `GIGIApp.MainTabView.task` calls `GigiBrainDiagnostics.shared.startMonitoring()` at launch.

## Why
The rest of #16 (offline banner UI #62, Gemini fallback #63) need a single observable to bind to instead of detecting offline themselves. This sub puts that in place.

## Acceptance Criteria — verified on iPhone 17 Pro
- [x] AC1: `GigiBrainDiagnostics` is `@MainActor final class ObservableObject` with `@Published harnessStatus`
- [x] AC2: `startMonitoring()` polls every 5s in foreground / 30s in background
- [x] AC3: 2+ consecutive failures → `harnessStatus == .offline` (verified: `degraded → offline (consecutiveFailures=2)`)
- [x] AC4: 1 success after offline → `harnessStatus == .online` (verified: `Harness recovery: offline → online`)
- [x] AC5: `sendJSON` backoff array is `[0, 1000, 2000, 4000]ms`
- [x] AC6: Monitor started at app launch from `MainTabView.task`
- [x] AC7: `xcodebuild -configuration Debug` = BUILD SUCCEEDED

## Device evidence

```
DEBUG LOG: GigiBrainDiagnostics.swift:61 tick() — Harness status: unknown → degraded (consecutiveFailures=1)
DEBUG LOG: GigiBrainDiagnostics.swift:61 tick() — Harness status: degraded → offline (consecutiveFailures=2)
DEBUG LOG: GigiBrainDiagnostics.swift:54 tick() — Harness recovery: offline → online
```

Full E2E cycle (kill → restart harness on Mac) reflected correctly in published state.

## Test plan
- [x] AC1-AC7 verified (see above)
- [x] BUILD SUCCEEDED on Mac (generic/platform=iOS, Debug, no codesign)
- [x] Runtime test on iPhone 17 Pro with harness on/off cycle

cc @ArmandoBattaglino