### PR TITLE
fix(ios): declare live activity support on widget extension

### DIFF
--- a/02_GIGI_APP/GIGIWidget/Info.plist
+++ b/02_GIGI_APP/GIGIWidget/Info.plist
@@ -7,5 +7,9 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## 🎯 Cosa stiamo facendo (context)
Sblocchiamo il QA gate Dynamic Island dopo #119: la build Sideloadly/free-cert non è affidabile per verificare Live Activities sul device PM. Durante il build paid ho verificato che Xcode 17 rifiuta le chiavi entitlement ActivityKit manuali; il contratto valido è plist Live Activities + provisioning paid per app e widget.

## 🔧 Cosa implementerà il dev
- Dichiara Live Activities anche nel plist della Widget Extension.
- Mantiene invariati gli entitlements firmati: Xcode 17 rifiuta le chiavi ActivityKit manuali come non valide.
- Produce una IPA development paid per i due device registrati nel provisioning profile.

## ✨ Risultato atteso
Il PM può installare la IPA paid e verificare Dynamic Island senza il blocco del free-cert sideload.

## What
- Added `NSSupportsLiveActivities` and `NSSupportsLiveActivitiesFrequentUpdates` to `02_GIGI_APP/GIGIWidget/Info.plist`.

## Why
The PM must verify Dynamic Island on physical hardware with a paid-signed build. Pure `main` already had Live Activities enabled for the app target, but the widget extension plist did not advertise Live Activity support, and Xcode 17 rejects manual ActivityKit entitlement keys as invalid.

## Evidence
- Archive succeeded: `/tmp/GIGI-QA-LiveActivities.xcarchive`.
- Export succeeded: `~/Desktop/GIGI-QA-IPA/GIGI-QA-LiveActivities-2026-04-28.ipa`.
- IPA app plist: `NSSupportsLiveActivities=true`, `NSSupportsLiveActivitiesFrequentUpdates=true`.
- IPA widget plist: `NSSupportsLiveActivities=true`, `NSSupportsLiveActivitiesFrequentUpdates=true`.
- Profiles signed by Team `R5N92QSPQ6`, devices: `00008110-001608EC02F0A01E`, `00008150-000239490CEA401C`.

## Test plan
- [x] `xcodebuild archive -project 02_GIGI_APP/GIGI.xcodeproj -scheme GIGI -configuration Release -destination generic/platform=iOS -allowProvisioningUpdates`
- [x] `xcodebuild -exportArchive ... method=development`
- [x] unzip IPA + inspect app/widget Info.plist and signed entitlements
- [ ] PM installs paid IPA and verifies Dynamic Island AC on physical iPhone

Refs #119
Refs #17
Refs #85
Refs #103
