### PR TITLE
feat(infra): smart session-start dashboard — 3 column layout (Actionable / Waiting / PR Review)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -150,7 +150,7 @@ LOCAL_MD="$ROOT/CLAUDE.local.md"
 HAS_LOCAL_MD="false"
 [ -f "$LOCAL_MD" ] && HAS_LOCAL_MD="true"
 
-# 4. Recupera issue aperte assegnate al dev
+# 4. Recupera issue aperte assegnate al dev + PR aperte del repo (condivise tra tutti)
 ISSUES_JSON="$(gh issue list --repo Building-addicts/GIGI \
   --assignee "$HANDLE" --state open --limit 30 \
   --json number,title,labels 2>/dev/null)"
@@ -159,13 +159,31 @@ if [ -z "$ISSUES_JSON" ]; then
   ISSUES_JSON="[]"
 fi
 
-# 5. Format con python (sort per priorità, top 8). Forza UTF-8 per emoji su Windows.
-FORMATTED="$(ISSUES_JSON_ENV="$ISSUES_JSON" PYTHONIOENCODING=utf-8 "$PY" - <<'PYEOF'
+# Le PR aperte sono visibili a tutti i dev — non filtrate per author. Top 2 per relevance.
+PRS_JSON="$(gh pr list --repo Building-addicts/GIGI --state open --limit 20 \
+  --json number,title,author,reviewDecision,statusCheckRollup 2>/dev/null)"
+
+if [ -z "$PRS_JSON" ]; then
+  PRS_JSON="[]"
+fi
+
+# 5. Format con python — dashboard a 3 colonne (Actionable / Waiting / PR Review).
+#    Forza UTF-8 per emoji su Windows.
+FORMATTED="$(ISSUES_JSON_ENV="$ISSUES_JSON" PRS_JSON_ENV="$PRS_JSON" HANDLE_ENV="$HANDLE" \
+  PYTHONIOENCODING=utf-8 "$PY" - <<'PYEOF'
 import json, os, sys
+
 try:
     issues = json.loads(os.environ.get('ISSUES_JSON_ENV', '[]'))
 except Exception:
     issues = []
+
+try:
+    prs = json.loads(os.environ.get('PRS_JSON_ENV', '[]'))
+except Exception:
+    prs = []
+
+handle = os.environ.get('HANDLE_ENV', '')
 
 def priority_score(issue):
     labels = [l['name'] for l in issue.get('labels', [])]
@@ -174,35 +192,82 @@ def priority_score(issue):
         if p in labels: return 1 + i
     return 99
 
-issues.sort(key=lambda i: (priority_score(i), i['number']))
+def is_blocked(issue):
+    """Issue è blocked se ha label 'blocked' esplicita.
+    (Marker comment <!-- BLOCKING:N,M --> verrà aggiunto in futuro se serve — costoso fetchare comment per ogni issue.)"""
+    labels = [l['name'] for l in issue.get('labels', [])]
+    return 'blocked' in labels
 
-emoji_map = {
-    'priority:P0': '🔴',
-    'priority:P1': '🟧',
-    'priority:P2': '🟨',
-    'priority:P3': '🟩',
-}
-
-lines = []
-for issue in issues[:8]:
+def render_issue_line(issue, with_blocked_hint=False):
     labels = [l['name'] for l in issue.get('labels', [])]
     pri_label = next((l for l in labels if l.startswith('priority:')), '')
-    pri_emoji = emoji_map.get(pri_label, '⚪')
+    pri_emoji = {'priority:P0':'🔴','priority:P1':'🟧','priority:P2':'🟨','priority:P3':'🟩'}.get(pri_label, '⚪')
     blocker = '🚨' if 'release-blocker' in labels else ''
     bug = '🐛' if 'bug' in labels else ''
-    title = issue['title'][:80]
-    lines.append(f"  {pri_emoji}{blocker}{bug} #{issue['number']} — {title}")
+    title = issue['title'][:75]
+    line = f"  {pri_emoji}{blocker}{bug} #{issue['number']} — {title}"
+    if with_blocked_hint:
+        line += "  ⏸️ blocked"
+    return line
 
-# Stampa righe seguite da una marker line con il count (così bash sa dove tagliare)
-for line in lines:
+def render_pr_status(pr):
+    review = pr.get('reviewDecision') or ''
+    if review == 'CHANGES_REQUESTED':
+        return '🔴 changes requested'
+    if review == 'APPROVED':
+        return '✅ approved'
+    checks = pr.get('statusCheckRollup') or []
+    if any(c.get('conclusion') == 'FAILURE' for c in checks):
+        return '🔴 CI failing'
+    if checks and all((c.get('conclusion') == 'SUCCESS' or c.get('status') == 'COMPLETED') for c in checks):
+        return '✅ CI green'
+    return '⏳ pending'
+
+def render_pr_line(pr):
+    title = pr['title'][:55]
+    author = (pr.get('author') or {}).get('login', '?')
+    is_mine = '👤 ' if author == handle else ''
+    return f"  {is_mine}PR #{pr['number']} — {title} (by @{author}) [{render_pr_status(pr)}]"
+
+# Sort issue per priority, poi numero
+issues.sort(key=lambda i: (priority_score(i), i['number']))
+
+# Categorize: actionable vs waiting
+actionable = [i for i in issues if not is_blocked(i)][:3]
+waiting    = [i for i in issues if     is_blocked(i)][:3]
+
+# PR rilevanti: prima quelle del dev attuale, poi le altre. Max 2.
+prs_sorted = sorted(prs, key=lambda p: (0 if (p.get('author') or {}).get('login') == handle else 1, -int(p['number'])))
+prs_top    = prs_sorted[:2]
+
+# Render output
+out_lines = []
+if actionable:
+    out_lines.append("🟢 ACTIONABLE NOW")
+    for i in actionable:
+        out_lines.append(render_issue_line(i))
+if waiting:
+    if out_lines: out_lines.append("")
+    out_lines.append("🟡 WAITING (blocked by dependency)")
+    for i in waiting:
+        out_lines.append(render_issue_line(i, with_blocked_hint=True))
+if prs_top:
+    if out_lines: out_lines.append("")
+    out_lines.append("🔴 PR IN REVIEW (shared, all devs)")
+    for p in prs_top:
+        out_lines.append(render_pr_line(p))
+
+for line in out_lines:
     print(line)
 print(f"__ISSUE_COUNT__={len(issues)}")
+print(f"__ACTIONABLE_FIRST__={actionable[0]['number'] if actionable else ''}")
 PYEOF
 )"
 
-# Estrai count dalla marker line, e issue lines = tutto prima del marker
+# Estrai metadata dalle marker line
 ISSUE_COUNT="$(echo "$FORMATTED" | grep -oE '^__ISSUE_COUNT__=[0-9]+$' | tail -1 | cut -d= -f2)"
-ISSUE_LINES="$(echo "$FORMATTED" | grep -v '^__ISSUE_COUNT__=')"
+FIRST_ACTIONABLE="$(echo "$FORMATTED" | grep -oE '^__ACTIONABLE_FIRST__=[0-9]*$' | tail -1 | cut -d= -f2)"
+ISSUE_LINES="$(echo "$FORMATTED" | grep -v '^__ISSUE_COUNT__=' | grep -v '^__ACTIONABLE_FIRST__=')"
 
 # 6. Componi messaggio di benvenuto + istruzioni di workflow
 echo "[GIGI session-start] — context per Claude"
@@ -227,14 +292,19 @@ ISTRUZIONI per Claude in questa sessione:
 - Digli: "Ciao $FULL_NAME 👋 Non hai issue aperte assegnate al momento. Vuoi che controlliamo il Project board cosa è disponibile? https://github.com/orgs/Building-addicts/projects/1"
 EOF
 else
+  FIRST_DISPLAY="${FIRST_ACTIONABLE:-N}"
   cat <<EOF
-Issue aperte assegnate ($ISSUE_COUNT totali, top 8 per priorità):
+Dashboard ($ISSUE_COUNT issue assegnate · max 3+3+2 righe):
+
 $ISSUE_LINES
 
 ISTRUZIONI VINCOLANTI per Claude in questa sessione:
 
-1. Quando il dev scrive il primo messaggio, SALUTALO per nome e mostragli la prima issue in cima:
-   "Ciao $FULL_NAME 👋 Hai $ISSUE_COUNT issue aperte. La più urgente è #N. Vuoi che la facciamo? (rispondi 'sì')"
+1. Quando il dev scrive il primo messaggio, SALUTALO per nome e mostragli la prima issue ACTIONABLE (🟢):
+   "Ciao $FULL_NAME 👋 Hai $ISSUE_COUNT issue assegnate. La prossima actionable è #${FIRST_DISPLAY}. Vuoi che la facciamo? (rispondi 'sì')"
+
+   Le issue in 🟡 WAITING sono bloccate da dipendenze — non proporle finché il blocker non è risolto.
+   Le PR in 🔴 PR REVIEW sono per visibilità condivisa: il dev può commentarle / fare review se vuole, ma non sono "issue da iniziare".
 
 2. Se il dev dice "sì" / "vai" / "ok": segui il DEV WORKFLOW in CLAUDE.md §"Workflow per dev (vibe-coder mode)". Passi:
    a. Crea worktree: git worktree add ../GIGI-work/issue-<N>-<slug> -b feat/issue-<N>-<slug> main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,11 +111,29 @@ Il **Test E2E utente** deve rispecchiare letteralmente il "Risultato atteso" com
 #### 1. Onboarding sessione (auto via SessionStart hook)
 All'apertura, l'hook ti dà già:
 - nome del dev + handle GitHub (da `.claude/dev-mapping.json`)
-- lista delle sue issue aperte assegnate, ordinate per priorità (release-blocker → P0 → P1 → P2 → P3)
+- **dashboard a 3 colonne** delle issue assegnate + PR aperte del repo
 - istruzioni vincolanti (riassunte qui)
 
-**Tu (Claude del dev)** saluti per nome e proponi la **prima** issue in cima. Esempio:
-> "Ciao Leo 👋 Hai 4 issue aperte. La più urgente è #9 — Dynamic Island descent. Vuoi iniziare? (rispondi 'sì')"
+Il dashboard si compone di 3 sezioni (max 3+3+2 = 8 righe totali):
+
+| Colonna | Cosa mostra | Quando proporla al dev |
+|---|---|---|
+| 🟢 **ACTIONABLE NOW** | Issue open senza dipendenze attive — ordinate per priorità (release-blocker → P0→P3) | Sempre. Proponi la prima al dev |
+| 🟡 **WAITING** | Issue con label `blocked` esplicita — bloccate da dipendenze | Skip. Mostra ma NON proporre come "iniziamo" |
+| 🔴 **PR IN REVIEW** | Tutte le PR aperte del repo (visibili a tutti i dev) — `[👤 PR #N]` per le PR del dev attuale | Per visibilità + eventuale review. Non sono "issue da iniziare" |
+
+**Tu (Claude del dev)** saluti per nome e proponi la **prima issue in 🟢 ACTIONABLE**. Esempio:
+> "Ciao Leo 👋 Hai 4 issue assegnate. La prossima actionable è #9 — Dynamic Island descent. Vuoi iniziare? (rispondi 'sì')"
+
+Se 🟢 è vuoto (tutte le issue del dev sono blocked), comunicalo:
+> "Tutte le tue issue sono bloccate da dipendenze. Vuoi vedere la lista 🟡 waiting per un check rapido?"
+
+**Convention per finire in colonna giusta**:
+- Per mettere issue in 🟡 WAITING: aggiungi label `blocked` (manuale dal PM/dev)
+- Per togliere da 🟡: rimuovi label `blocked` quando dipendenza è risolta
+- Marker comment `<!-- BLOCKING:N,M -->` su PR è già in uso per blocking comments (vedi #127), ma NON viene parsato dal session-start (sarebbe troppo costoso fetchare comment di ogni issue). Per ora basta label esplicita.
+
+Vedi `docs/runbooks/session-start-dashboard.md` per troubleshoot.
 
 #### 2. Avvio lavoro (su "sì" del dev)
 

--- a/docs/runbooks/session-start-dashboard.md
+++ b/docs/runbooks/session-start-dashboard.md
@@ -1,0 +1,125 @@
+# Runbook — Session-start dashboard (3 colonne)
+
+> Quando ti serve: capire cosa l'hook `.claude/hooks/session-start.sh` mostra ai dev all'apertura di Claude Code, come marcare le issue per finire in colonna giusta, troubleshoot output bizzarro.
+>
+> Owner: PM (Armando) per la convention; tutti i dev per uso quotidiano.
+
+## Cosa è il dashboard
+
+All'apertura di Claude Code, il SessionStart hook stampa un dashboard breve (max 8 righe) diviso in 3 colonne:
+
+```
+🟢 ACTIONABLE NOW                                  ← cosa puoi iniziare ORA (max 3)
+  🔴🚨 #65 — Voice & Wake W2 quiet + W3 noise...
+  🔴🚨 #66 — Dynamic Island D1 + Follow-up F1/F2...
+  🟧 #130 — feat(infra): smart session-start...
+
+🟡 WAITING (blocked by dependency)                 ← bloccate da dipendenze (max 3)
+  🔴🚨 #17 — [QA] Pre-freeze QA gate                  ⏸️ blocked
+
+🔴 PR IN REVIEW (shared, all devs)                 ← PR aperte tutti, visibili a tutti (max 2)
+  PR #128 — feat(ios): Claude bridge auto-fallback (by @fc200490-sketch) [🔴 CI failing]
+  👤 PR #124 — feat(ios): persistent harness banner   (by @ArmandoBattaglino) [✅ CI green]
+```
+
+L'icona `👤` indica una PR che il dev attuale ha aperto (priority visibility).
+
+## Logica di categorizzazione
+
+### 🟢 Actionable
+Issue che soddisfano TUTTE queste condizioni:
+- `state: open`
+- Assegnata al dev
+- **NO label `blocked`**
+
+Ordinate per `priority_score`:
+- `release-blocker` → 0 (top)
+- `priority:P0` → 1
+- `priority:P1` → 2
+- `priority:P2` → 3
+- `priority:P3` → 4
+- nessun label priority → 99
+
+Stesso score → ordinate per numero issue (più vecchio prima).
+
+### 🟡 Waiting
+Issue che soddisfano:
+- `state: open`
+- Assegnata al dev
+- **HA label `blocked`** esplicita
+
+Stesso ordinamento di Actionable.
+
+### 🔴 PR in review
+PR aperte di **tutto il repo** (NON filtrate per author — visibili a tutti i dev):
+- Sort: prima le PR del dev attuale, poi le altre
+- Max 2 mostrate
+- Status icon:
+  - `✅ CI green` — tutti i check passati
+  - `✅ approved` — review approvata
+  - `🔴 CI failing` — almeno un check failed
+  - `🔴 changes requested` — review chiede modifiche
+  - `⏳ pending` — review/CI in corso
+
+## Come marcare issue per finire in colonna giusta
+
+### Mettere issue in 🟡 WAITING (= dipende da altra)
+
+```bash
+gh issue edit <N> --repo Building-addicts/GIGI --add-label blocked
+```
+
+Quando la dipendenza è risolta:
+
+```bash
+gh issue edit <N> --repo Building-addicts/GIGI --remove-label blocked
+```
+
+Best practice: aggiungi sempre nel body un **comment** che spiega COSA blocca, es.:
+
+```
+⏸️ Blocked by #127 — multi-instance Live Activities pollution.
+Riprenderò dopo merge fix #127.
+```
+
+### Verificare label `blocked` esistente
+
+La label `blocked` deve esistere nel repo. Se non c'è:
+
+```bash
+gh label create blocked --repo Building-addicts/GIGI \
+  --description "Blocked by dependency (parent issue or external resource)" \
+  --color "ededed"
+```
+
+## Troubleshoot
+
+### "Vedo issue X in colonna sbagliata"
+
+| Sintomo | Probabile causa | Fix |
+|---|---|---|
+| Issue blocked sta in 🟢 invece di 🟡 | Manca label `blocked` | `gh issue edit N --add-label blocked` |
+| Issue chiusa appare ancora | Cache locale gh CLI | Riapri Claude Code (rifa fetch) |
+| Tutte le sub QA gate (#65-#70) appaiono in 🟢 con stesso colore | Corretto: hanno tutte `release-blocker` + `P0`. Decisione PM 2026-04-29: parent epic non vanno in 🟡 anche se hanno sub aperte | Resta come è |
+| 🔴 PR section mostra PR di altri ma NON le mie | Le tue PR vengono prima per default — se mancano potrebbe essere che hai 0 PR aperte, oppure sono >2 e quelle altrui rientrano nel top-2 | Conta `gh pr list --author @me --state open` |
+| 🟢 vuoto, tutte in 🟡 | Tutte le tue issue sono blocked. Sblocca quelle resolvable | rimuovi label da issue completate, oppure prendi una PR review da 🔴 |
+
+### "Output troppo lungo / non vedo bene il messaggio"
+
+Limit attuale: max 3 actionable + 3 waiting + 2 PR = 8 righe issue + 3 header + 2 separatori = ~13 righe. Se vedi più, è un bug del rendering — apri issue.
+
+### "Il dashboard non si aggiorna"
+
+Causa: hook session-start gira **una sola volta all'apertura**. Per vedere stato fresh, riapri Claude Code (`Ctrl+D` poi rilancia).
+
+## Convention future (parking lot)
+
+Se serve in futuro:
+- **Marker comment `<!-- BLOCKING:N,M -->`** automatico — costoso fetchare comment di ogni issue (1 API call extra per issue), valutare se vale per repo grandi
+- **Auto-detect parent epic con sub aperte** → 🟡 — decisione attuale (2026-04-29) PM: NON farlo, parent epic resta 🟢 release-blocker
+- **GitHub Action auto-clear blocked label** quando issue dipendenza chiude — utile ma scope separato
+
+## Riferimenti
+- File hook: `.claude/hooks/session-start.sh` — Python embedded section ~163-260
+- Decisione architetturale: issue #130
+- Background motivante: PM feedback 2026-04-29 ore 03:30 — "ranking sembra a caso"


### PR DESCRIPTION
Closes #130

## What
Refactor di `.claude/hooks/session-start.sh` Python embedded section: dashboard a 3 colonne all'apertura di Claude Code invece di lista flat top-8.

| Sezione | Max | Criteri |
|---|---|---|
| 🟢 **ACTIONABLE NOW** | 3 | Issue open assegnate al dev, NO label `blocked`. Sort: priority_score → numero issue |
| 🟡 **WAITING** | 3 | Issue open assegnate, CON label `blocked` (esplicita) |
| 🔴 **PR IN REVIEW** | 2 | TUTTE le PR aperte del repo (condivise tra dev). Author dev attuale viene first; status icon: ✅/🔴/⏳ |

## Decisioni progettuali (PM Armando 2026-04-29)
1. **PR section condivisa** — non filtrata per author. Tutti i dev vedono tutte le PR.
2. **Parent epic con sub-issue open NON auto-blocked** — resta 🟢 release-blocker. Solo label `blocked` esplicita triggera 🟡.
3. **Marker comment `<!-- BLOCKING:N,M -->` non parsato** — costo API per ogni issue (1 fetch comments call ognuna). Parking lot per future enhancement.

## Files
- `.claude/hooks/session-start.sh` — refactor Python embedded
- `CLAUDE.md` §"Workflow per dev" — aggiornata sezione Onboarding
- `docs/runbooks/session-start-dashboard.md` (nuovo) — guida convention + troubleshoot

## Test plan
- [x] Syntax check `bash -n` → OK
- [x] Live run su PM Armando con 17 issue + 11 PR aperte:
  - 🟢 mostra 3 issue (#17, #65, #66) ordinate corretto
  - 🟡 vuoto (nessuna label `blocked` ancora applicata) — sezione skipped silently
  - 🔴 mostra 2 PR (#128 CI failing, #124 CI green) con author info
- [x] Label `blocked` creata nel repo (gh label create)

## Convention introdotta
Per mettere issue in 🟡 WAITING:
```bash
gh issue edit <N> --repo Building-addicts/GIGI --add-label blocked
```

Per togliere quando dipendenza è risolta:
```bash
gh issue edit <N> --remove-label blocked
```

## Sblocca
- Visibility migliorata per dev all'apertura sessione (focus su actionable, blocked separate)
- Convention chiara per PM per orchestrare priorità / blocking dependency

cc @fc200490-sketch @Leonardo-Corte — quando aprite Claude Code in questo repo, vedrete il nuovo dashboard