### PR TITLE
feat(ios): wire GigiTaskExtractor to PresenceSession via memory observer (Sub #14 2/3)

### DIFF
--- a/02_GIGI_APP/GIGI/GigiConversationMemory.swift
+++ b/02_GIGI_APP/GIGI/GigiConversationMemory.swift
@@ -57,6 +57,14 @@ final class GigiConversationMemory: ObservableObject {
         trimIfNeeded()
     }
 
+    func recentUserTranscript(turns: Int = 6) -> String {
+        messages
+            .filter { $0.role == .user }
+            .suffix(turns)
+            .map { "- \($0.text)" }
+            .joined(separator: "\n")
+    }
+
     func addThinking() -> UUID {
         let msg = GigiMessage(role: .gigi, text: "", isThinking: true)
         messages.append(msg)

--- a/02_GIGI_APP/GIGI/PresenceSessionController.swift
+++ b/02_GIGI_APP/GIGI/PresenceSessionController.swift
@@ -53,6 +53,10 @@ final class PresenceSessionController: ObservableObject {
     private var durationTask: Task<Void, Never>?
     private var standaloneMuted = false
 
+    // Sub #14 2/3: live task extraction
+    private var turnCounter: Int = 0
+    private var extractionTask: Task<Void, Never>?
+
     private init() {
         GigiDebugLogger.log("PresenceSessionController init START")
         observeOrchestrator()
@@ -147,6 +151,9 @@ final class PresenceSessionController: ObservableObject {
 
         inactivityTask?.cancel()
         durationTask?.cancel()
+        extractionTask?.cancel()
+        GigiTaskExtractor.shared.clear()
+        turnCounter = 0
         GigiAudioManager.shared.stopAll()
 
         Task {
@@ -287,6 +294,16 @@ final class PresenceSessionController: ObservableObject {
                 self.lastTranscript = text
                 self.state = .thinking
                 await GigiLiveActivityController.shared.updatePresence(state: .thinking, message: "Thinking about it", transcript: text)
+
+                // Sub #14 2/3: trigger task extraction every 2 user turns
+                self.turnCounter += 1
+                if self.turnCounter % 2 == 0 {
+                    self.extractionTask?.cancel()
+                    self.extractionTask = Task {
+                        let transcript = await GigiConversationMemory.shared.recentUserTranscript(turns: 6)
+                        await GigiTaskExtractor.shared.extract(from: transcript)
+                    }
+                }
             }
         }
     }

--- a/02_GIGI_APP/GIGI/PresenceSessionController.swift
+++ b/02_GIGI_APP/GIGI/PresenceSessionController.swift
@@ -54,7 +54,8 @@ final class PresenceSessionController: ObservableObject {
     private var standaloneMuted = false
 
     // Sub #14 2/3: live task extraction
-    private var turnCounter: Int = 0
+    @Published private(set) var turnCounter: Int = 0
+    @Published private(set) var lastExtractionAt: Date?
     private var extractionTask: Task<Void, Never>?
     private var userTurnsCancellable: AnyCancellable?
     private var lastObservedUserCount: Int = 0
@@ -80,12 +81,14 @@ final class PresenceSessionController: ObservableObject {
                 guard userCount > self.lastObservedUserCount else { return }
                 self.lastObservedUserCount = userCount
                 self.turnCounter += 1
+                print("[PresenceSession] turnCounter=\(self.turnCounter)")
                 GigiDebugLogger.log("PresenceSession turnCounter=\(self.turnCounter)")
                 if self.turnCounter % 2 == 0 {
                     self.extractionTask?.cancel()
-                    self.extractionTask = Task {
+                    self.extractionTask = Task { @MainActor [weak self] in
                         let transcript = await GigiConversationMemory.shared.recentUserTranscript(turns: 6)
                         await GigiTaskExtractor.shared.extract(from: transcript)
+                        self?.lastExtractionAt = Date()
                     }
                 }
             }

--- a/02_GIGI_APP/GIGI/PresenceSessionController.swift
+++ b/02_GIGI_APP/GIGI/PresenceSessionController.swift
@@ -56,13 +56,39 @@ final class PresenceSessionController: ObservableObject {
     // Sub #14 2/3: live task extraction
     private var turnCounter: Int = 0
     private var extractionTask: Task<Void, Never>?
+    private var userTurnsCancellable: AnyCancellable?
+    private var lastObservedUserCount: Int = 0
 
     private init() {
         GigiDebugLogger.log("PresenceSessionController init START")
         observeOrchestrator()
         GigiDebugLogger.log("PresenceSessionController observeOrchestrator OK")
         observeDynamicIslandCommands()
+        observeUserTurnsForExtraction()
         GigiDebugLogger.log("PresenceSessionController init END")
+    }
+
+    // Sub #14 2/3: observe ConversationMemory user messages instead of wrapping
+    // GigiAudioManager.onTranscription (which is owned by GigiSmartOrchestrator and
+    // would be overwritten by last-writer-wins on singleton init order).
+    private func observeUserTurnsForExtraction() {
+        userTurnsCancellable = GigiConversationMemory.shared.$messages
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] messages in
+                guard let self, self.isActive else { return }
+                let userCount = messages.filter { $0.role == .user }.count
+                guard userCount > self.lastObservedUserCount else { return }
+                self.lastObservedUserCount = userCount
+                self.turnCounter += 1
+                GigiDebugLogger.log("PresenceSession turnCounter=\(self.turnCounter)")
+                if self.turnCounter % 2 == 0 {
+                    self.extractionTask?.cancel()
+                    self.extractionTask = Task {
+                        let transcript = await GigiConversationMemory.shared.recentUserTranscript(turns: 6)
+                        await GigiTaskExtractor.shared.extract(from: transcript)
+                    }
+                }
+            }
     }
 
     // MARK: - Session lifecycle
@@ -154,6 +180,7 @@ final class PresenceSessionController: ObservableObject {
         extractionTask?.cancel()
         GigiTaskExtractor.shared.clear()
         turnCounter = 0
+        lastObservedUserCount = GigiConversationMemory.shared.messages.filter { $0.role == .user }.count
         GigiAudioManager.shared.stopAll()
 
         Task {
@@ -295,15 +322,8 @@ final class PresenceSessionController: ObservableObject {
                 self.state = .thinking
                 await GigiLiveActivityController.shared.updatePresence(state: .thinking, message: "Thinking about it", transcript: text)
 
-                // Sub #14 2/3: trigger task extraction every 2 user turns
-                self.turnCounter += 1
-                if self.turnCounter % 2 == 0 {
-                    self.extractionTask?.cancel()
-                    self.extractionTask = Task {
-                        let transcript = await GigiConversationMemory.shared.recentUserTranscript(turns: 6)
-                        await GigiTaskExtractor.shared.extract(from: transcript)
-                    }
-                }
+                // Sub #14 2/3: extraction wiring moved to observeUserTurnsForExtraction()
+                // because onTranscription gets overwritten by GigiSmartOrchestrator init.
             }
         }
     }

--- a/02_GIGI_APP/GIGI/SettingsView.swift
+++ b/02_GIGI_APP/GIGI/SettingsView.swift
@@ -27,6 +27,7 @@ struct SettingsView: View {
     @AppStorage(GigiWakeWordEngine.userDefaultsEnabledKey) private var wakeWordEnabled = false
     @ObservedObject private var audioManager = GigiAudioManager.shared
     @ObservedObject private var presence = PresenceSessionController.shared
+    @ObservedObject private var taskExtractor = GigiTaskExtractor.shared
     @State private var ttsRate: Double = 0.52
     @State private var memoryCount = 0
     @State private var showClearMemoryAlert = false
@@ -588,6 +589,21 @@ struct SettingsView: View {
             }
 
             #if DEBUG
+            HStack {
+                Text("Live extractor status")
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("turn \(presence.turnCounter) · \(taskExtractor.tasks.count) tasks")
+                        .font(.caption.monospacedDigit())
+                        .foregroundColor(.secondary)
+                    if let ts = presence.lastExtractionAt {
+                        Text("last extract: \(ts.formatted(date: .omitted, time: .standard))")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+
             Button("Test Task Extractor") {
                 Task {
                     let transcript = "I need to reply to Fede about the demo, prepare for the 3pm meeting, and book lunch with Marco tomorrow"


### PR DESCRIPTION
Closes #54

> ⚠️ **Stacked PR** — base = \`feat/issue-53-task-extractor\` (PR #134, Sub 1/3). Da rebasare su \`main\` quando #134 è mergiata.

## What
- \`GigiConversationMemory.recentUserTranscript(turns:)\` — ultimi N \`.user\` messages formattati con prefisso \`- \`
- \`PresenceSessionController\`:
  - \`@Published turnCounter\` + \`@Published lastExtractionAt\` (per UI live indicator)
  - \`extractionTask: Task<Void, Never>?\` cancellable
  - \`observeUserTurnsForExtraction()\`: subscribe Combine a \`GigiConversationMemory.\$messages\`, ogni nuovo \`.user\` message → counter += 1, ogni 2 turni → cancel task precedente + nuova \`extract()\` in background
  - \`stopSession()\`: cancel task, \`clear()\` extractor, reset counter, baseline lastObservedUserCount
- \`SettingsView\` Debug section: live indicator \`turn N · M tasks · last extract HH:mm:ss\`

## Why
Sub 2/3 di #14. Engine standalone (1/3) ora innescato durante Talking Session reale. Niente blocco TTS, niente spam (debounce coperto da \`inFlight\` in extractor).

### Deviazione dalla spec del body issue
Il body diceva di wrappare \`GigiAudioManager.onTranscription\`. Test E2E iniziale ha rivelato che **non funziona**: \`GigiSmartOrchestrator.init\` (line 58) sovrascrive \`onTranscription\` senza preservare handler precedente — last-writer-wins su singleton init order. Il wrap di Presence veniva perso.

**Fix:** observe \`GigiConversationMemory.\$messages\` con Combine. Ogni nuovo \`.user\` message = un turno reale, decoupled da audio pipeline. Più robusto, indipendente da init order.

## Test plan
Verificato su iPhone 17 Pro (Xcode Run da Mac) tramite UI live indicator in Settings → Debug:
- [x] AC1: \`recentUserTranscript(turns:)\` presente in \`GigiConversationMemory\` ✅
- [x] AC2: turnCounter incrementato a ogni nuovo user message ✅ (visto live in UI: turn 1, turn 2, turn 3, turn 4)
- [x] AC3: \`extract\` invocato ogni 2 turni utente ✅ (timestamp \`last extract\` aggiornato a turno 2, turno 4)
- [x] AC4: \`stopSession\` cancella task, chiama clear, resetta counter ✅ (UI mostra \`turn 0 · 0 tasks\` dopo stop)
- [x] AC5: niente extraction se Presence non attiva ✅ (sink ha guard \`isActive\`)
- [x] AC6: BUILD SUCCEEDED ✅ (Xcode 26.4.1, Mac M1)

## Notes
- Diagnostica iniziale logs Xcode console era fuorviante (console disconnect intermittente). UI live indicator risolve dipendenza da console streaming.
- 1 fix in-PR durante E2E: \`onTranscription\` → \`\$messages\` observer (commit \`5d8b19f\`)
- Bottoni \`#if DEBUG\` di #53 e nuovo \"Live extractor status\" restano per testing 3/3, da rimuovere a fine parent #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)