### PR TITLE
feat(infra): GitHub Actions auto-blocked label + PR marker cleanup

### DIFF
--- a/.github/workflows/auto-blocked-label.yml
+++ b/.github/workflows/auto-blocked-label.yml
@@ -1,0 +1,107 @@
+# Auto-add `blocked` label to issues that reference other open issues with
+# patterns like "Blocked by #N", "Depends on #N", "Waiting on #N", "Aspetto #N".
+#
+# Trigger: issue.opened/edited + issue_comment.created/edited
+# - Reads issue body + last 5 comments
+# - Extracts referenced issue numbers via regex
+# - Applies `blocked` label if at least ONE referenced issue is still OPEN
+# - No-op if label already present, or if all references are closed
+#
+# Sister workflows:
+# - auto-unblock.yml          (removes label when dependency closes)
+# - auto-clear-pr-blocking-marker.yml  (PR <!-- BLOCKING --> marker cleanup)
+
+name: Auto Blocked Label
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  detect-blocked:
+    runs-on: ubuntu-latest
+    # Skip on PR comments (issue_comment fires on PRs too — we only care issues)
+    if: ${{ !github.event.issue.pull_request }}
+    steps:
+      - name: Detect blocked-by references and apply label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            // 1. Fetch issue + last 5 comments
+            const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number });
+
+            const comments_resp = await github.rest.issues.listComments({
+              owner, repo, issue_number,
+              per_page: 100,
+            });
+            const last_comments = comments_resp.data.slice(-5);
+            const text = (issue.body || '') + '\n' + last_comments.map(c => c.body || '').join('\n');
+
+            // 2. Match patterns
+            const patterns = [
+              /\bblocked\s*(?:by|from)\s*[:#]?\s*#?(\d+)/gi,
+              /\bdepends?\s+on\s+#?(\d+)/gi,
+              /\bwaiting\s+(?:on|for)\s+#?(\d+)/gi,
+              /\baspetto\s+(?:la\s+)?(?:issue\s+|chiusura\s+(?:di\s+)?)?#(\d+)/gi,
+              /\bstand-?by\s+(?:on|finch[eé]|fino\s+a)\s+#?(\d+)/gi,
+            ];
+
+            const refs = new Set();
+            for (const p of patterns) {
+              for (const m of text.matchAll(p)) {
+                const n = parseInt(m[1] ?? m[2], 10);
+                if (!isNaN(n) && n !== issue_number) refs.add(n);
+              }
+            }
+
+            console.log(`Issue #${issue_number}: extracted refs = [${[...refs].join(', ')}]`);
+
+            if (refs.size === 0) {
+              console.log('No blocked-by references detected — no-op.');
+              return;
+            }
+
+            // 3. Check if at least one reference is still OPEN
+            let any_open = false;
+            for (const n of refs) {
+              try {
+                const { data: ref_issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
+                if (ref_issue.state === 'open') {
+                  any_open = true;
+                  console.log(`  ref #${n}: OPEN → blocking confirmed`);
+                  break;
+                } else {
+                  console.log(`  ref #${n}: CLOSED → not blocking`);
+                }
+              } catch (e) {
+                console.log(`  ref #${n}: NOT FOUND or inaccessible (${e.message}) → skip`);
+              }
+            }
+
+            if (!any_open) {
+              console.log('All referenced issues are closed — no-op.');
+              return;
+            }
+
+            // 4. Apply `blocked` label if not already present
+            const current_labels = (issue.labels || []).map(l => typeof l === 'string' ? l : l.name);
+            if (current_labels.includes('blocked')) {
+              console.log('Label `blocked` already present — no-op.');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number,
+              labels: ['blocked'],
+            });
+            console.log(`✓ Applied label \`blocked\` to issue #${issue_number}`);

--- a/.github/workflows/auto-clear-pr-blocking-marker.yml
+++ b/.github/workflows/auto-clear-pr-blocking-marker.yml
@@ -1,0 +1,99 @@
+# Auto-post clearance comment on PRs whose blocking marker references the
+# issue that was just closed.
+#
+# Trigger: issues.closed
+# - Scans open PRs (and recently merged ones, optional) for marker `<!-- BLOCKING:N,M,... -->`
+# - If marker contains the closed issue number AND all listed numbers are now closed,
+#   posts `✅ All blocking issues resolved — PR ready for review`
+#
+# Sister workflows: auto-blocked-label.yml, auto-unblock.yml
+
+name: Auto Clear PR Blocking Marker
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: read
+  pull-requests: write
+  contents: read
+
+jobs:
+  clear-pr-marker:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request }}
+    steps:
+      - name: Scan open PRs for matching BLOCKING marker
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const closed_issue_number = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            console.log(`Issue #${closed_issue_number} closed — scanning PRs for BLOCKING marker`);
+
+            // 1. List open PRs
+            const prs_resp = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+            console.log(`Open PRs: ${prs_resp.length}`);
+
+            const marker_re = /<!--\s*BLOCKING:\s*([\d,\s]+)\s*-->/i;
+
+            for (const pr of prs_resp) {
+              const pr_number = pr.number;
+
+              // Fetch comments of the PR
+              const comments_resp = await github.rest.issues.listComments({
+                owner, repo, issue_number: pr_number, per_page: 100,
+              });
+
+              for (const c of comments_resp.data) {
+                const m = (c.body || '').match(marker_re);
+                if (!m) continue;
+
+                // Extract numbers
+                const nums = m[1].split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n));
+                if (!nums.includes(closed_issue_number)) continue;
+
+                console.log(`  PR #${pr_number}: marker found with [${nums.join(',')}]`);
+
+                // Check that ALL numbers are now closed
+                let all_closed = true;
+                const open_remaining = [];
+                for (const n of nums) {
+                  try {
+                    const { data: ref_issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
+                    if (ref_issue.state === 'open') {
+                      all_closed = false;
+                      open_remaining.push(n);
+                    }
+                  } catch (e) {
+                    console.log(`    ref #${n} unreachable: ${e.message}`);
+                  }
+                }
+
+                if (all_closed) {
+                  // Check we haven't already posted clearance for this set
+                  const existing_clearance_re = /✅ All blocking issues resolved/i;
+                  const has_clearance = comments_resp.data.some(cc => existing_clearance_re.test(cc.body || ''));
+                  if (has_clearance) {
+                    console.log(`    PR #${pr_number}: clearance comment already posted — skip`);
+                    break;
+                  }
+
+                  await github.rest.issues.createComment({
+                    owner, repo, issue_number: pr_number,
+                    body: `✅ All blocking issues resolved (${nums.map(n => `#${n}`).join(', ')}) — PR ready for review.`,
+                  });
+                  console.log(`    PR #${pr_number}: ✓ posted clearance`);
+                } else {
+                  console.log(`    PR #${pr_number}: still blocked by [${open_remaining.join(',')}] — no comment`);
+                }
+                break; // only process first matching marker comment per PR
+              }
+            }
+
+            console.log('auto-clear-pr-blocking-marker done');

--- a/.github/workflows/auto-unblock.yml
+++ b/.github/workflows/auto-unblock.yml
@@ -1,0 +1,110 @@
+# Auto-remove `blocked` label from issues that referenced this issue when
+# this issue gets closed.
+#
+# Trigger: issues.closed
+# - Searches all open issues with label `blocked`
+# - For each: re-runs the detection logic (same patterns as auto-blocked-label.yml)
+# - If NO open dependency remains, removes label + posts clearance comment
+#
+# Multi-dep safe: if issue A is blocked by both #1 and #2, closing #1 leaves
+# the label intact because #2 is still open.
+
+name: Auto Unblock
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  unblock-dependents:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request }}
+    steps:
+      - name: Find dependents and remove blocked label if all deps closed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const closed_issue_number = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            console.log(`Issue #${closed_issue_number} closed — searching dependents`);
+
+            // 1. Search open issues with label `blocked`
+            const search_q = `repo:${owner}/${repo} is:issue is:open label:blocked`;
+            const search_resp = await github.rest.search.issuesAndPullRequests({
+              q: search_q,
+              per_page: 100,
+            });
+            const blocked_issues = search_resp.data.items || [];
+            console.log(`Found ${blocked_issues.length} open blocked issues`);
+
+            // 2. Re-run detection logic on each
+            const patterns = [
+              /\bblocked\s*(?:by|from)\s*[:#]?\s*#?(\d+)/gi,
+              /\bdepends?\s+on\s+#?(\d+)/gi,
+              /\bwaiting\s+(?:on|for)\s+#?(\d+)/gi,
+              /\baspetto\s+(?:la\s+)?(?:issue\s+|chiusura\s+(?:di\s+)?)?#(\d+)/gi,
+              /\bstand-?by\s+(?:on|finch[eé]|fino\s+a)\s+#?(\d+)/gi,
+            ];
+
+            for (const item of blocked_issues) {
+              const n = item.number;
+              if (n === closed_issue_number) continue;
+
+              // Fetch full issue + comments
+              const { data: full } = await github.rest.issues.get({ owner, repo, issue_number: n });
+              const comments_resp = await github.rest.issues.listComments({ owner, repo, issue_number: n, per_page: 100 });
+              const last_comments = comments_resp.data.slice(-10);
+              const text = (full.body || '') + '\n' + last_comments.map(c => c.body || '').join('\n');
+
+              // Extract refs
+              const refs = new Set();
+              for (const p of patterns) {
+                for (const m of text.matchAll(p)) {
+                  const r = parseInt(m[1] ?? m[2], 10);
+                  if (!isNaN(r) && r !== n) refs.add(r);
+                }
+              }
+
+              if (!refs.has(closed_issue_number)) {
+                console.log(`  #${n}: no ref to closed #${closed_issue_number} — skip`);
+                continue;
+              }
+
+              // Check if any other ref is still OPEN
+              let any_other_open = false;
+              for (const r of refs) {
+                if (r === closed_issue_number) continue; // skip the one just closed
+                try {
+                  const { data: rissue } = await github.rest.issues.get({ owner, repo, issue_number: r });
+                  if (rissue.state === 'open') {
+                    any_other_open = true;
+                    console.log(`  #${n}: ref #${r} still OPEN — keep blocked`);
+                    break;
+                  }
+                } catch (e) {
+                  // Ignore not-found
+                }
+              }
+
+              if (any_other_open) continue;
+
+              // Remove label + post comment
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: n, name: 'blocked' });
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: n,
+                  body: `✅ Blocked-by #${closed_issue_number} resolved — \`blocked\` label removed automatically. Issue ready to work on.`,
+                });
+                console.log(`  #${n}: ✓ unblocked`);
+              } catch (e) {
+                console.log(`  #${n}: failed to unblock: ${e.message}`);
+              }
+            }
+
+            console.log('auto-unblock done');

--- a/docs/runbooks/session-start-dashboard.md
+++ b/docs/runbooks/session-start-dashboard.md
@@ -112,14 +112,46 @@ Limit attuale: max 3 actionable + 3 waiting + 2 PR = 8 righe issue + 3 header + 
 
 Causa: hook session-start gira **una sola volta all'apertura**. Per vedere stato fresh, riapri Claude Code (`Ctrl+D` poi rilancia).
 
+## Automazione GitHub Actions (post #136)
+
+Da issue #136 mergiata, la label `blocked` viene gestita **automaticamente** da 3 workflow:
+
+### `.github/workflows/auto-blocked-label.yml`
+- **Trigger**: issue opened/edited + comment created/edited
+- **Logic**: cerca pattern `Blocked by #N` / `Depends on #N` / `Waiting on #N` / `Aspetto #N` / `Stand-by on #N` (case-insensitive, italiano + inglese) nel body + ultimi 5 comment. Se almeno una issue referenziata è OPEN → applica label `blocked`.
+
+### `.github/workflows/auto-unblock.yml`
+- **Trigger**: issue closed
+- **Logic**: trova tutte le issue open con label `blocked` che la referenziano, ri-runna detection. Se NESSUNA dipendenza open resta → rimuove label `blocked` + posta `✅ Blocked-by #N resolved — unblocked` automatic.
+
+### `.github/workflows/auto-clear-pr-blocking-marker.yml`
+- **Trigger**: issue closed
+- **Logic**: scansiona PR aperte cercando marker `<!-- BLOCKING:N,M -->`. Se la issue chiusa è nel marker e TUTTI i numeri nel marker sono ora closed → posta `✅ All blocking issues resolved — PR ready for review`.
+
+### Quando NON funziona automatico
+
+I workflow girano solo se l'issue/comment usa un pattern riconosciuto. Se scrivi *"questa dipende dall'altra"* senza `#N`, niente è detected. Sempre meglio:
+
+```markdown
+⏸️ Blocked by #127 — multi-instance Live Activities pollution.
+Riprenderò dopo merge fix.
+```
+
+Per un fallback manuale (override automatic detection):
+
+```bash
+gh issue edit <N> --add-label blocked    # forza in 🟡
+gh issue edit <N> --remove-label blocked # forza out
+```
+
 ## Convention future (parking lot)
 
 Se serve in futuro:
-- **Marker comment `<!-- BLOCKING:N,M -->`** automatico — costoso fetchare comment di ogni issue (1 API call extra per issue), valutare se vale per repo grandi
 - **Auto-detect parent epic con sub aperte** → 🟡 — decisione attuale (2026-04-29) PM: NON farlo, parent epic resta 🟢 release-blocker
-- **GitHub Action auto-clear blocked label** quando issue dipendenza chiude — utile ma scope separato
+- **Auto-detect Polish edge cases**: pattern in altre lingue (es. portuguese, francese) — solo se entra dev non it/en
 
 ## Riferimenti
 - File hook: `.claude/hooks/session-start.sh` — Python embedded section ~163-260
 - Decisione architetturale: issue #130
+- Automazione: issue #136
 - Background motivante: PM feedback 2026-04-29 ore 03:30 — "ranking sembra a caso"


### PR DESCRIPTION
Closes #136

## What
3 GitHub Actions workflow per gestire automaticamente la label `blocked` introdotta in #130:

| Workflow | Trigger | Logic |
|---|---|---|
| `auto-blocked-label.yml` | issue opened/edited + comment created/edited | Pattern detection → applica label `blocked` se referenziata issue è OPEN |
| `auto-unblock.yml` | issue closed | Search blocked issues → rimuove label se nessuna dep open resta + posta clearance comment |
| `auto-clear-pr-blocking-marker.yml` | issue closed | Scansiona PR aperte per marker `<!-- BLOCKING:N,M -->` → posta `✅ All blocking issues resolved` se tutti closed |

Pattern detection (case-insensitive, italiano + inglese):
- `Blocked by #N` / `Blocked from #N`
- `Depends on #N`
- `Waiting on #N` / `Waiting for #N`
- `Aspetto #N` / `Aspetto chiusura di #N`
- `Stand-by on #N` / `Stand-by finché #N`

## Why
Post #130 (smart dashboard), la label `blocked` veniva applicata MANUALMENTE dal PM. Per renderlo davvero automatico (PM feedback 2026-04-29 03:50: "rendiamolo intereamente automatico"), 3 workflow GitHub Actions sostituiscono completamente il workflow manuale.

## Test plan
- [x] YAML syntax check (Python yaml.safe_load) → 3/3 OK
- [x] Permission scoping minimum: issues:write + pull-requests:write
- [x] Multi-dep safe: rimuove label SOLO se nessuna altra dep open resta
- [x] Idempotente: no-op se label già presente, no double-clearance comment
- [ ] **Live test post-merge**: aprire issue con `Blocked by #99` (open) → entro 30s riceve label
- [ ] **Live test post-merge**: chiudere #89 → #90 (che la referenzia) viene auto-unblocked

Live test viene fatto dopo merge perché Actions si attivano solo su `main`.

## Permission scope
- `auto-blocked-label.yml`: `issues:write, contents:read`
- `auto-unblock.yml`: `issues:write, contents:read`
- `auto-clear-pr-blocking-marker.yml`: `issues:read, pull-requests:write, contents:read`

GITHUB_TOKEN built-in basta, nessun secret extra.

## Sblocca
- Zero manutenzione manuale per `blocked` label (PM e dev non devono ricordarsi di add/remove)
- PR blocking comment cleanup automatico → review-ready signals chiari quando issue collegate chiudono

## Note di implementation
- Skip su PR comments (issue_comment fires anche su PR — filter `!github.event.issue.pull_request`)
- Self-reference protection: l'issue non può blocco se stessa
- Marker idempotenza: scan precedente clearance comment prima di postare nuovo