### PR TITLE
feat(ios): talkingSessionTaskListView overlay laterale interattivo (Sub #14 3/3)

### DIFF
--- a/02_GIGI_APP/GIGI/MainTabView.swift
+++ b/02_GIGI_APP/GIGI/MainTabView.swift
@@ -90,9 +90,23 @@ struct MainTabView: View {
                     .transition(.opacity)
                     .zIndex(99)
             }
+
+            // Sub #14 3/3: Talking Session task list overlay — sibling of TabView
+            // so its DragGesture does not conflict with TabView page swipe.
+            if presence.isActive && !showOnboarding {
+                HStack {
+                    Spacer()
+                    TalkingSessionTaskListView()
+                        .padding(.top, 120)
+                        .padding(.trailing, 12)
+                }
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+                .zIndex(48)
+            }
         }
         .animation(.easeInOut(duration: 0.4), value: showOnboarding)
         .animation(.easeInOut(duration: 0.3), value: harnessConfigured)
+        .animation(.easeInOut(duration: 0.3), value: presence.isActive)
         .sheet(isPresented: $showPresence) {
             PresenceView()
                 .presentationDetents([.large])

--- a/02_GIGI_APP/GIGI/MainTabView.swift
+++ b/02_GIGI_APP/GIGI/MainTabView.swift
@@ -93,7 +93,8 @@ struct MainTabView: View {
 
             // Sub #14 3/3: Talking Session task list overlay — sibling of TabView
             // so its DragGesture does not conflict with TabView page swipe.
-            if presence.isActive && !showOnboarding {
+            // Visible only on Chat tab (selection == 0).
+            if presence.isActive && !showOnboarding && selection == 0 {
                 HStack {
                     Spacer()
                     TalkingSessionTaskListView()
@@ -107,6 +108,7 @@ struct MainTabView: View {
         .animation(.easeInOut(duration: 0.4), value: showOnboarding)
         .animation(.easeInOut(duration: 0.3), value: harnessConfigured)
         .animation(.easeInOut(duration: 0.3), value: presence.isActive)
+        .animation(.easeInOut(duration: 0.25), value: selection)
         .sheet(isPresented: $showPresence) {
             PresenceView()
                 .presentationDetents([.large])

--- a/02_GIGI_APP/GIGI/TalkingSessionTaskListView.swift
+++ b/02_GIGI_APP/GIGI/TalkingSessionTaskListView.swift
@@ -3,61 +3,126 @@ import SwiftUI
 struct TalkingSessionTaskListView: View {
     @ObservedObject var extractor = GigiTaskExtractor.shared
 
+    @AppStorage("gigi.tasklist.collapsed") private var isCollapsed: Bool = false
+    @AppStorage("gigi.tasklist.offsetX") private var savedOffsetX: Double = 0
+    @AppStorage("gigi.tasklist.offsetY") private var savedOffsetY: Double = 0
+
+    @State private var dragTranslation: CGSize = .zero
+
+    private var totalOffset: CGSize {
+        CGSize(width: savedOffsetX + dragTranslation.width,
+               height: savedOffsetY + dragTranslation.height)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 6) {
-                Image(systemName: "checklist")
-                    .font(.system(size: 13))
-                    .foregroundStyle(.cyan)
-                Text("Tasks")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.white)
-                Spacer()
-                if extractor.isExtracting {
-                    ProgressView()
-                        .scaleEffect(0.6)
-                        .tint(.cyan)
-                }
-            }
+            header
 
-            if extractor.tasks.isEmpty {
-                Text("Listening for tasks…")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.white.opacity(0.4))
-                    .italic()
-            } else {
-                ForEach(extractor.tasks) { task in
-                    HStack(alignment: .top, spacing: 6) {
-                        Image(systemName: "circle")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.5))
-                            .padding(.top, 1)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(task.title)
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(.white)
-                                .fixedSize(horizontal: false, vertical: true)
-                            if let dl = task.deadline, !dl.isEmpty {
-                                Text(dl)
-                                    .font(.system(size: 10))
-                                    .foregroundStyle(.orange.opacity(0.85))
-                            }
-                            if let vip = task.vipContact, !vip.isEmpty {
-                                Text("⭐ \(vip)")
-                                    .font(.system(size: 10))
-                                    .foregroundStyle(.yellow)
-                            }
-                        }
-                        Spacer(minLength: 0)
-                    }
-                    .transition(.opacity.combined(with: .move(edge: .trailing)))
-                }
+            if !isCollapsed {
+                content
             }
         }
         .padding(10)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-        .frame(maxWidth: 200, alignment: .leading)
+        .frame(maxWidth: isCollapsed ? 130 : 200, alignment: .leading)
+        .offset(totalOffset)
+        .gesture(dragGesture)
+        .animation(.easeInOut(duration: 0.2), value: isCollapsed)
         .animation(.easeInOut(duration: 0.25), value: extractor.tasks.count)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "checklist")
+                .font(.system(size: 13))
+                .foregroundStyle(.cyan)
+            Text("Tasks")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+            if isCollapsed && !extractor.tasks.isEmpty {
+                Text("(\(extractor.tasks.count))")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.cyan.opacity(0.8))
+            }
+            Spacer()
+            if extractor.isExtracting {
+                ProgressView()
+                    .scaleEffect(0.6)
+                    .tint(.cyan)
+            }
+            Button {
+                isCollapsed.toggle()
+            } label: {
+                Image(systemName: isCollapsed ? "chevron.left" : "chevron.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.6))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if extractor.tasks.isEmpty {
+            Text("Listening for tasks…")
+                .font(.system(size: 11))
+                .foregroundStyle(.white.opacity(0.4))
+                .italic()
+        } else {
+            ForEach(extractor.tasks) { task in
+                taskRow(task)
+                    .transition(.opacity.combined(with: .move(edge: .trailing)))
+            }
+        }
+    }
+
+    private func taskRow(_ task: ExtractedTask) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "circle")
+                .font(.system(size: 11))
+                .foregroundStyle(.white.opacity(0.5))
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(task.title)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let dl = task.deadline, !dl.isEmpty {
+                    Text(dl)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.orange.opacity(0.85))
+                }
+                if let vip = task.vipContact, !vip.isEmpty {
+                    Text("⭐ \(vip)")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.yellow)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Drag gesture
+
+    private var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                dragTranslation = value.translation
+            }
+            .onEnded { value in
+                let proposedX = savedOffsetX + value.translation.width
+                let proposedY = savedOffsetY + value.translation.height
+                // Soft clamp to keep card mostly on screen (assume ~400 px headroom each side)
+                savedOffsetX = max(-260, min(40, proposedX))
+                savedOffsetY = max(-100, min(500, proposedY))
+                dragTranslation = .zero
+            }
     }
 }
 

--- a/02_GIGI_APP/GIGI/TalkingSessionTaskListView.swift
+++ b/02_GIGI_APP/GIGI/TalkingSessionTaskListView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct TalkingSessionTaskListView: View {
+    @ObservedObject var extractor = GigiTaskExtractor.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "checklist")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.cyan)
+                Text("Tasks")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
+                Spacer()
+                if extractor.isExtracting {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .tint(.cyan)
+                }
+            }
+
+            if extractor.tasks.isEmpty {
+                Text("Listening for tasks…")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.4))
+                    .italic()
+            } else {
+                ForEach(extractor.tasks) { task in
+                    HStack(alignment: .top, spacing: 6) {
+                        Image(systemName: "circle")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.white.opacity(0.5))
+                            .padding(.top, 1)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(task.title)
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.white)
+                                .fixedSize(horizontal: false, vertical: true)
+                            if let dl = task.deadline, !dl.isEmpty {
+                                Text(dl)
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.orange.opacity(0.85))
+                            }
+                            if let vip = task.vipContact, !vip.isEmpty {
+                                Text("⭐ \(vip)")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.yellow)
+                            }
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .trailing)))
+                }
+            }
+        }
+        .padding(10)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .frame(maxWidth: 200, alignment: .leading)
+        .animation(.easeInOut(duration: 0.25), value: extractor.tasks.count)
+    }
+}
+
+#if DEBUG
+#Preview("Empty") {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        TalkingSessionTaskListView()
+    }
+}
+#endif

--- a/02_GIGI_APP/GIGI/TalkingSessionTaskListView.swift
+++ b/02_GIGI_APP/GIGI/TalkingSessionTaskListView.swift
@@ -26,7 +26,7 @@ struct TalkingSessionTaskListView: View {
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
         .frame(maxWidth: isCollapsed ? 130 : 200, alignment: .leading)
         .offset(totalOffset)
-        .gesture(dragGesture)
+        .highPriorityGesture(dragGesture)
         .animation(.easeInOut(duration: 0.2), value: isCollapsed)
         .animation(.easeInOut(duration: 0.25), value: extractor.tasks.count)
     }


### PR DESCRIPTION
Closes #55

## What
- **NEW** `02_GIGI_APP/GIGI/TalkingSessionTaskListView.swift` — SwiftUI overlay with:
  - Header: checklist icon + 'Tasks' + ProgressView on `isExtracting` + chevron toggle
  - Empty state: 'Listening for tasks…' italic
  - Task list: title + orange deadline + ⭐ yellow VIP badge
  - Fade-in + slide animation on new task
  - **Interactive bonus**: chevron collapse → compact `Tasks (N)` pill, DragGesture for free repositioning (soft-clamp at edges), `@AppStorage` persistent (collapsed state + offset cross-session)
- `02_GIGI_APP/GIGI/MainTabView.swift` — overlay as sibling of TabView in root ZStack, gated by `presence.isActive && selection == 0` (Chat tab)

## Why
Sub 3/3 of #14 — closes the parent epic. Makes AC#5 of MVP visible ('Gigi extracts tasks from conversation', `docs/MVP_SCOPE.md` §287). During chat or voice flow the user sees tasks emerge live on the right of the screen as if someone were taking notes for them.

### Deviations from issue body spec (motivated by E2E test)
1. **Overlay not in ChatView but in MainTabView**: the body said to embed it in ChatView. E2E test revealed the TabView has `.simultaneousGesture` for page swipe (MainTabView line 49) which intercepted the card's DragGesture → dragging the card changed tab. Architectural fix: overlay as sibling of TabView, isolated from parent gesture.
2. **Gating selection == 0**: per dev UX request — overlay only on Chat tab, not Dashboard/Settings.
3. **Added interactivity** (collapse + drag + persist): not in original AC, added during E2E to avoid having a rigid overlay in demo.

## Test plan — verified on iPhone 17 Pro by @fc200490-sketch (2026-04-29)
- [x] AC1: `TalkingSessionTaskListView.swift` exists and compiles ✅ (#Preview available)
- [x] AC2: visible in UI ONLY when `presence.isActive == true` && Chat tab selected ✅
- [x] AC3: empty state 'Listening for tasks…' ✅
- [x] AC4: task row with title + orange deadline + ⭐ yellow VIP ✅
- [x] AC5: fade-in + slide animation on new task ✅
- [x] AC6: `BUILD SUCCEEDED` ✅ (Xcode 26.4.1, Mac M1)
- [x] AC7: AC#5 of MVP_SCOPE.md §287 visible in UI ✅
- [x] **Bonus**: chevron collapse → pill, drag for repositioning, persist between sessions, no conflict with TabView swipe

## Step Report
**Cosa abbiamo implementato**: la lista task estratti è ora visibile in UI come overlay laterale in `MainTabView` (sibling del `TabView`, gated by `presence.isActive && selection == 0`). Include header con checklist icon, lista interattiva (collapse chevron + drag riposizionabile + persist via `@AppStorage`), animazione fade-in/slide su nuovo task.

**Cosa è ora possibile**: l'AC#5 dell'MVP ('Gigi extracts tasks from conversation') è completo end-to-end — extract automatic ogni 2 turni utente (sub 2/3, già su main) + lista visibile live (questa sub). User vede i task crescere mentre parla con GIGI.

**Prossimo passo**: parent #14 chiusa al 100% (3/3 sub merged). Si passa al prossimo parent epic actionable.

## Notes
- Branch was rebased on main 2026-05-04 (cherry-picked the 5 #55-only commits, dropped the redundant #53/#54 commits which already shipped via PR #173 and earlier). Final diff: 2 files (`MainTabView.swift` modified, `TalkingSessionTaskListView.swift` new).
- Build verify after rebase: `BUILD SUCCEEDED` (xcodebuild via SSH on Mac).
- Admin merge requested by @fc200490-sketch — strada A scope confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)