### PR TITLE
feat(infra): post-mvp scope deescalation — Claude PM auto-applies label on voice command

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -193,10 +193,20 @@ def priority_score(issue):
     return 99
 
 def is_blocked(issue):
-    """Issue è blocked se ha label 'blocked' esplicita.
-    (Marker comment <!-- BLOCKING:N,M --> verrà aggiunto in futuro se serve — costoso fetchare comment per ogni issue.)"""
+    """Issue è in 🟡 WAITING se ha label 'blocked' (dipendenza tecnica) o
+    'post-mvp' (scope deescalato dal PM, riprende v1.1).
+    Entrambe semanticamente = "non actionable adesso, non proporre al dev"."""
     labels = [l['name'] for l in issue.get('labels', [])]
-    return 'blocked' in labels
+    return 'blocked' in labels or 'post-mvp' in labels
+
+def blocked_reason(issue):
+    """Etichetta della ragione di blocco — usata nel render."""
+    labels = [l['name'] for l in issue.get('labels', [])]
+    if 'post-mvp' in labels:
+        return 'post-mvp'
+    if 'blocked' in labels:
+        return 'blocked'
+    return ''
 
 def render_issue_line(issue, with_blocked_hint=False):
     labels = [l['name'] for l in issue.get('labels', [])]
@@ -207,7 +217,11 @@ def render_issue_line(issue, with_blocked_hint=False):
     title = issue['title'][:75]
     line = f"  {pri_emoji}{blocker}{bug} #{issue['number']} — {title}"
     if with_blocked_hint:
-        line += "  ⏸️ blocked"
+        reason = blocked_reason(issue)
+        if reason == 'post-mvp':
+            line += "  ⏸️ post-mvp (deescalated to v1.1)"
+        else:
+            line += "  ⏸️ blocked"
     return line
 
 def render_pr_status(pr):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,75 @@ Prima di postare comment/body issue/PR che menzionano una dipendenza, Claude DEV
 
 Vedi `docs/runbooks/session-start-dashboard.md` per details + GitHub Actions logic.
 
+### 🎚️ Procedura deescalation scope — comando vocale del PM
+
+**Quando il PM (@ArmandoBattaglino) dice una frase come**:
+
+| Trigger riconosciuti | Esempio |
+|---|---|
+| `"sposto X a fine"` / `"X a fine"` | *"sposto wake word a fine"* |
+| `"deferred X"` / `"X deferred"` | *"deferred always-listening"* |
+| `"X post-mvp"` / `"post-mvp X"` | *"wake word post-mvp"* |
+| `"metto in pausa X"` | *"metto in pausa il NLU"* |
+| `"deescala X"` / `"deescalate X"` | *"deescala wake word"* |
+
+**Claude del PM DEVE eseguire questa sequenza**:
+
+1. **Identifica scope X**: keyword da matchare nel titolo/body delle issue/PR open. Esempi:
+   - "wake word" → grep `wake|wake-word|hey gigi` in titoli
+   - "always listening" → grep `always.listen|always-listening`
+   - "NLU" → grep `nlu|intent`
+
+2. **Esegui search**:
+   ```bash
+   gh search issues --repo Building-addicts/GIGI --state open "<keyword>" --json number,title,labels
+   gh search prs --repo Building-addicts/GIGI --state open "<keyword>" --json number,title
+   ```
+
+3. **Mostra al PM lista deduplicata** delle issue/PR trovate, con label corrente:
+   ```
+   Trovate 13 issue/PR che toccano "wake word":
+     #65 (no label)        Voice & Wake — W2/W3/W4...
+     #66 (no label)        Dynamic Island D1 + Follow-up...
+     ...
+     #115 [post-mvp] (già) voice: barge-in inconsistente
+     PR #85 (no label)     always-listening consent flow
+     PR #103 (no label)    wake word de-scope
+     PR #106 (no label)    NLU intents
+
+   Procedo ad applicare label `post-mvp` a tutte (escluso #115 già marcata)?
+   ```
+
+4. **Su conferma PM** ("sì" / "vai" / "ok"):
+   - Per ogni issue/PR senza label `post-mvp`:
+     ```bash
+     gh issue edit <N> --repo Building-addicts/GIGI --add-label post-mvp
+     ```
+     (per PR: `gh pr edit <N> --add-label post-mvp`)
+   - Posta comment standardizzato:
+     ```
+     ⏸️ Deescalated to post-MVP by PM @ArmandoBattaglino YYYY-MM-DD —
+     "<scope X>" feature resumes in v1.1.
+     ```
+
+5. **Conferma al PM**: `✅ <N> issue/PR ora in 🟡 WAITING al prossimo session-start dei dev.`
+
+#### Comando inverso — "ripristino X" / "riprendiamo X"
+
+Stessa logica al contrario:
+1. Search issue/PR con label `post-mvp` + keyword scope
+2. Mostra lista al PM
+3. Su conferma: `gh issue edit N --remove-label post-mvp` + comment `▶️ Resumed from post-MVP by @ArmandoBattaglino YYYY-MM-DD — back to active queue.`
+
+#### Differenza `blocked` vs `post-mvp`
+
+| Label | Quando usarla | Riprende quando |
+|---|---|---|
+| `blocked` | Dipendenza tecnica concreta da altra issue/PR aperta. Pattern auto-detected. | Dependency closes (Action 2 rimuove auto) |
+| `post-mvp` | Decisione di scope dal PM. Feature spostata a v1.1. | PM dice "ripristino X" (manuale, non auto) |
+
+Entrambe finiscono in 🟡 WAITING dashboard, ma con label diversa per chiarezza.
+
 ### Flusso completo per ogni issue (da seguire alla lettera)
 
 #### 1. Onboarding sessione (auto via SessionStart hook)

--- a/docs/runbooks/session-start-dashboard.md
+++ b/docs/runbooks/session-start-dashboard.md
@@ -144,6 +144,23 @@ gh issue edit <N> --add-label blocked    # forza in 🟡
 gh issue edit <N> --remove-label blocked # forza out
 ```
 
+## Label `post-mvp` — scope deescalation dal PM (issue #153)
+
+Oltre alla label `blocked` (dipendenza tecnica), il sistema riconosce anche **`post-mvp`** come trigger 🟡 WAITING:
+
+| Label | Significato | Chi la applica | Chi la rimuove |
+|---|---|---|---|
+| `blocked` | Dipendenza tecnica concreta su altra issue/PR. Auto-detected dai pattern `Blocked by #N` etc. | Action 1 `auto-blocked-label.yml` | Action 2 `auto-unblock.yml` quando dependency closes |
+| `post-mvp` | Decisione PM di spostare scope a v1.1. Es. "wake word post-mvp" | Claude del PM su comando vocale (vedi CLAUDE.md §"Procedura deescalation scope") | Claude del PM su "ripristino X" |
+
+Issue con `post-mvp` mostrano: `⏸️ post-mvp (deescalated to v1.1)` nel dashboard 🟡, distinguibile da `blocked` che mostra solo `⏸️ blocked`.
+
+### Comando vocale PM
+
+> *"sposto wake word a fine"* → Claude del PM identifica issue/PR collegate, chiede conferma, applica label + comment standard.
+
+Vedi `CLAUDE.md` §"🎚️ Procedura deescalation scope" per details.
+
 ## Convention future (parking lot)
 
 Se serve in futuro:
@@ -154,4 +171,6 @@ Se serve in futuro:
 - File hook: `.claude/hooks/session-start.sh` — Python embedded section ~163-260
 - Decisione architetturale: issue #130
 - Automazione: issue #136
+- Convention OBBLIGO Claude del dev: issue #139
+- Scope deescalation `post-mvp`: issue #153
 - Background motivante: PM feedback 2026-04-29 ore 03:30 — "ranking sembra a caso"


### PR DESCRIPTION
Closes #153

## What
3 cambi sincronizzati per supportare scope deescalation del PM:

1. **Hook `session-start.sh`** — `is_blocked()` riconosce label `post-mvp` oltre `blocked`. Render line distinguibile.
2. **CLAUDE.md** — Nuova sub-sezione "🎚️ Procedura deescalation scope": comando vocale PM ("sposto X a fine") → Claude identifica issue/PR + applica label.
3. **Runbook** — Sezione confronto `blocked` vs `post-mvp`.

## Why
PM diceva "i dev hanno spostato wake word a post-MVP, ma il sistema dashboard non lo riflette". Adesso 1 frase del PM ("sposto wake word a fine") deescala 13 issue/PR insieme.

## Test plan
- [x] `bash -n` syntax → OK
- [x] Live dashboard run: issue con label `post-mvp` esistente (#115, #116) finiscono in 🟡 WAITING con `⏸️ post-mvp (deescalated to v1.1)` ✓
- [x] Issue con label `blocked` (es. #90) continuano a finire in 🟡 con `⏸️ blocked` (regression test)

## Sblocca
PM autonomo per gestire scope deescalation in 1 frase. Dev vedono naturalmente solo cosa è actionable adesso.