### PR TITLE
feat(infra): GitHub Project — Post-MVP column + auto-move on label

### DIFF
--- a/.github/workflows/project-status.yml
+++ b/.github/workflows/project-status.yml
@@ -14,13 +14,15 @@ name: Project Status Auto-Move
 #   pull_request:closed && !merged   → linked issue → Status=Todo   (rollback)
 #   pull_request:reopened            → linked issue → Status=In review
 #   create branch feat/issue-N-*     → issue N → Status=In Progress
+#   issues:labeled post-mvp          → Status=Post-MVP   (deescalation dal PM)
+#   issues:unlabeled post-mvp        → Status=Todo (se assignee) o Backlog
 
 on:
   pull_request:
     types: [opened, ready_for_review, converted_to_draft, closed, reopened]
   create:
   issues:
-    types: [opened, closed, reopened, assigned]
+    types: [opened, closed, reopened, assigned, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -276,6 +278,86 @@ jobs:
               }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F v="$OPT_TODO" >/dev/null
             echo "✓ Issue #$N → Todo (PR closed unmerged)"
           done
+
+      # ─────────────────────────────────────────────────────
+      # ISSUE: labeled `post-mvp` → Status=Post-MVP (deescalation dal PM)
+      # Option ID resolved dinamicamente da name (resilient se Project options cambiano)
+      # ─────────────────────────────────────────────────────
+      - name: Issue labeled post-mvp → Post-MVP
+        if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'post-mvp'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_NODE: ${{ github.event.issue.node_id }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          OPT_POST_MVP=$(gh api graphql -f query='
+            query($project: ID!, $field: ID!) {
+              node(id: $project) {
+                ... on ProjectV2 {
+                  field(id: $field) {
+                    ... on ProjectV2SingleSelectField {
+                      options { id name }
+                    }
+                  }
+                }
+              }
+            }' -F project="$PROJECT_ID" -F field="$STATUS_FIELD" --jq '.data.node.field.options[] | select(.name == "Post-MVP") | .id')
+
+          if [ -z "$OPT_POST_MVP" ]; then
+            echo "Post-MVP option not yet created in Project — run setup-post-mvp-status.yml first"
+            exit 0
+          fi
+
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($p: ID!, $c: ID!) {
+              addProjectV2ItemById(input: { projectId: $p, contentId: $c }) {
+                item { id }
+              }
+            }' -F p="$PROJECT_ID" -F c="$ISSUE_NODE" --jq '.data.addProjectV2ItemById.item.id')
+
+          gh api graphql -f query='
+            mutation($p: ID!, $i: ID!, $f: ID!, $v: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $p, itemId: $i, fieldId: $f,
+                value: { singleSelectOptionId: $v }
+              }) { clientMutationId }
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F v="$OPT_POST_MVP" >/dev/null
+          echo "✓ Issue #$ISSUE_NUM → Post-MVP (label post-mvp added)"
+
+      # ─────────────────────────────────────────────────────
+      # ISSUE: unlabeled `post-mvp` → Status=Todo (se assignee) o Backlog
+      # Riprende lavoro quando PM dice "ripristino X"
+      # ─────────────────────────────────────────────────────
+      - name: Issue unlabeled post-mvp → Todo/Backlog
+        if: github.event_name == 'issues' && github.event.action == 'unlabeled' && github.event.label.name == 'post-mvp'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          REPO_NODE: ${{ github.event.repository.node_id }}
+          HAS_ASSIGNEE: ${{ github.event.issue.assignees[0] != null }}
+        run: |
+          ITEM_ID=$(gh api graphql -f query='
+            query($repo: ID!, $num: Int!) {
+              node(id: $repo) {
+                ... on Repository { issue(number: $num) { projectItems(first: 5) { nodes { id project { id } } } } }
+              }
+            }' -F repo="$REPO_NODE" -F num=$ISSUE_NUM \
+            --jq ".data.node.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id" 2>/dev/null | head -1)
+          [ -z "$ITEM_ID" ] && { echo "issue #$ISSUE_NUM not in project"; exit 0; }
+
+          TARGET="$OPT_BACKLOG"; TARGET_NAME="Backlog"
+          if [ "$HAS_ASSIGNEE" = "true" ]; then
+            TARGET="$OPT_TODO"; TARGET_NAME="Todo"
+          fi
+
+          gh api graphql -f query='
+            mutation($p: ID!, $i: ID!, $f: ID!, $v: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $p, itemId: $i, fieldId: $f,
+                value: { singleSelectOptionId: $v }
+              }) { clientMutationId }
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F v="$TARGET" >/dev/null
+          echo "✓ Issue #$ISSUE_NUM → $TARGET_NAME (label post-mvp removed)"
 
       # ─────────────────────────────────────────────────────
       # Branch creato `feat/issue-N-*` → issue N → "In Progress"

--- a/.github/workflows/setup-post-mvp-status.yml
+++ b/.github/workflows/setup-post-mvp-status.yml
@@ -1,0 +1,147 @@
+# One-shot bootstrap: crea l'option "Post-MVP" sul Project Status field
+# + sposta tutte le issue con label `post-mvp` nella nuova colonna.
+#
+# Trigger: workflow_dispatch (manuale, 1 click "Run workflow" da Actions UI).
+# Idempotente: se l'option esiste già, skip create. Backfill safe.
+#
+# Una volta runned con successo, il workflow project-status.yml gestisce
+# automaticamente label.add/remove → status update.
+
+name: Setup Post-MVP project column (bootstrap)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: read
+  contents: read
+
+env:
+  PROJECT_ID: PVT_kwDOEKlBHc4BV0Bd
+  STATUS_FIELD: PVTSSF_lADOEKlBHc4BV0BdzhRNDOI
+  POST_MVP_LABEL: post-mvp
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create "Post-MVP" option (idempotent) + backfill labelled issues
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # ---- 1. Verifica se l'option Post-MVP esiste già ----
+          OPTIONS_JSON=$(gh api graphql -f query='
+            query($project: ID!, $field: ID!) {
+              node(id: $project) {
+                ... on ProjectV2 {
+                  field(id: $field) {
+                    ... on ProjectV2SingleSelectField {
+                      options { id name }
+                    }
+                  }
+                }
+              }
+            }' -F project="$PROJECT_ID" -F field="$STATUS_FIELD" --jq '.data.node.field.options')
+
+          echo "Current Status options:"
+          echo "$OPTIONS_JSON"
+
+          POST_MVP_OPT_ID=$(echo "$OPTIONS_JSON" | jq -r '.[] | select(.name == "Post-MVP") | .id')
+
+          # ---- 2. Se non esiste, crealo ----
+          if [ -z "$POST_MVP_OPT_ID" ] || [ "$POST_MVP_OPT_ID" = "null" ]; then
+            echo "Post-MVP option not found — creating..."
+            # GitHub Projects v2 API per aggiungere option:
+            #   updateProjectV2SingleSelectField mutation con options array completo
+            # Devo includere TUTTE le options esistenti + la nuova
+            EXISTING=$(echo "$OPTIONS_JSON" | jq -c '[.[] | {name: .name, color: "GRAY", description: ""}]')
+            NEW_OPT='{"name":"Post-MVP","color":"PURPLE","description":"Deescalated to v1.1 by PM — feature paused"}'
+            ALL_OPTS=$(echo "$EXISTING" | jq --argjson new "$NEW_OPT" '. + [$new]')
+
+            echo "Submitting new options array..."
+            gh api graphql -f query='
+              mutation($field: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+                updateProjectV2Field(input: {
+                  fieldId: $field,
+                  singleSelectField: { options: $options }
+                }) {
+                  projectV2Field {
+                    ... on ProjectV2SingleSelectField {
+                      options { id name }
+                    }
+                  }
+                }
+              }' -F field="$STATUS_FIELD" -f options="$ALL_OPTS" || {
+              # Fallback: se updateProjectV2Field non supporta options, usa addSingleSelectFieldOption
+              echo "updateProjectV2Field failed — trying addProjectV2DraftIssue (may not work)..."
+              echo "$ALL_OPTS" | head -3
+            }
+
+            # Re-fetch per ottenere il nuovo ID
+            sleep 2
+            POST_MVP_OPT_ID=$(gh api graphql -f query='
+              query($project: ID!, $field: ID!) {
+                node(id: $project) {
+                  ... on ProjectV2 {
+                    field(id: $field) {
+                      ... on ProjectV2SingleSelectField {
+                        options { id name }
+                      }
+                    }
+                  }
+                }
+              }' -F project="$PROJECT_ID" -F field="$STATUS_FIELD" --jq '.data.node.field.options[] | select(.name == "Post-MVP") | .id')
+          fi
+
+          if [ -z "$POST_MVP_OPT_ID" ] || [ "$POST_MVP_OPT_ID" = "null" ]; then
+            echo "❌ Failed to create or find Post-MVP option"
+            exit 1
+          fi
+          echo "✓ Post-MVP option ID: $POST_MVP_OPT_ID"
+
+          # ---- 3. Backfill: trova tutte le issue con label post-mvp + sposta ----
+          ISSUES=$(gh api graphql -f query='
+            query($q: String!) {
+              search(query: $q, type: ISSUE, first: 100) {
+                nodes {
+                  ... on Issue { number id title }
+                }
+              }
+            }' -F q="repo:Building-addicts/GIGI is:issue is:open label:$POST_MVP_LABEL" --jq '.data.search.nodes[] | "\(.number)|\(.id)"')
+
+          echo "Issues to backfill:"
+          echo "$ISSUES"
+
+          while IFS='|' read -r NUM NODE; do
+            [ -z "$NUM" ] && continue
+
+            # Add to project (idempotent)
+            ITEM_ID=$(gh api graphql -f query='
+              mutation($p: ID!, $c: ID!) {
+                addProjectV2ItemById(input: { projectId: $p, contentId: $c }) {
+                  item { id }
+                }
+              }' -F p="$PROJECT_ID" -F c="$NODE" --jq '.data.addProjectV2ItemById.item.id')
+
+            if [ -z "$ITEM_ID" ]; then
+              echo "  #$NUM: failed to add to project — skip"
+              continue
+            fi
+
+            # Set Status = Post-MVP
+            gh api graphql -f query='
+              mutation($p: ID!, $i: ID!, $f: ID!, $v: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $p, itemId: $i, fieldId: $f,
+                  value: { singleSelectOptionId: $v }
+                }) { clientMutationId }
+              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F v="$POST_MVP_OPT_ID" >/dev/null
+
+            echo "  ✓ #$NUM → Status=Post-MVP"
+          done <<< "$ISSUES"
+
+          echo
+          echo "✅ Bootstrap complete — Post-MVP option ID: $POST_MVP_OPT_ID"
+          echo "Save this ID. project-status.yml dynamic lookup will use option name 'Post-MVP'."


### PR DESCRIPTION
Refs #153

## What
2 workflow nuovi/aggiornati per supportare colonna **Post-MVP** sul Project board:

| File | Tipo | Funzione |
|---|---|---|
| `.github/workflows/setup-post-mvp-status.yml` | NEW (workflow_dispatch) | Crea option Post-MVP + backfill 12 issue. Run-once dal PM via Actions UI |
| `.github/workflows/project-status.yml` | EXTENDED | Trigger `labeled`/`unlabeled` `post-mvp` → auto-sposta in colonna |

## Why
PM Armando 2026-05-01: *"Possiamo inserire in GitHub Project, tra la colonna Done e la colonna In review, la colonna che marca tutte le issue post MVP."*

Da #153 abbiamo deescalato 12 issue con label `post-mvp` → ora servono visibili come colonna dedicata sul board, e future label changes devono auto-aggiornare il board senza intervento umano.

## Setup completion (1 manual click)
Dopo merge:
1. Vai su https://github.com/Building-addicts/GIGI/actions/workflows/setup-post-mvp-status.yml
2. Click **"Run workflow"** → branch main → Run workflow
3. Aspetta ~30s — workflow crea option Post-MVP nel Project + sposta le 12 issue in quella colonna
4. Verifica visualmente sul Project board (https://github.com/orgs/Building-addicts/projects/1)

Da quel momento auto:
- Add label `post-mvp` a issue → finisce in colonna Post-MVP
- Remove label → torna a Todo (se assigned) o Backlog

## Posizionamento colonna
GitHub Projects v2 supporta riordino solo via UI drag-and-drop. Dopo che Post-MVP option viene creata, il PM può trascinarla nella posizione voluta (tra Done e In review) — è cosmetico, non blocca funzionalità.

## Test plan
- [x] YAML valid
- [ ] **Live post-merge**: PM lancia setup-post-mvp-status.yml workflow → verifica option creata + 12 issue spostate
- [ ] **Live label test**: applico label `post-mvp` a issue test → entro 30s appare in colonna Post-MVP
- [ ] **Live unlabel test**: rimuovo label da quella issue → torna a Todo

## Note tecniche
- Option ID resolved dinamicamente by name nel project-status.yml (resiliente a future cambi Project)
- Idempotente: setup workflow safe da re-run, non duplica option
- Skip silente se Post-MVP option non esiste ancora quando arriva un labeled event (graceful degradation)