### PR TITLE
fix(workflows): graphql query Projects v2 — field(id:) not supported

### DIFF
--- a/.github/workflows/project-status.yml
+++ b/.github/workflows/project-status.yml
@@ -291,17 +291,19 @@ jobs:
           ISSUE_NUM: ${{ github.event.issue.number }}
         run: |
           OPT_POST_MVP=$(gh api graphql -f query='
-            query($project: ID!, $field: ID!) {
+            query($project: ID!) {
               node(id: $project) {
                 ... on ProjectV2 {
-                  field(id: $field) {
-                    ... on ProjectV2SingleSelectField {
-                      options { id name }
+                  fields(first: 50) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id options { id name }
+                      }
                     }
                   }
                 }
               }
-            }' -F project="$PROJECT_ID" -F field="$STATUS_FIELD" --jq '.data.node.field.options[] | select(.name == "Post-MVP") | .id')
+            }' -F project="$PROJECT_ID" --jq ".data.node.fields.nodes[] | select(.id == \"$STATUS_FIELD\") | .options[] | select(.name == \"Post-MVP\") | .id")
 
           if [ -z "$OPT_POST_MVP" ]; then
             echo "Post-MVP option not yet created in Project — run setup-post-mvp-status.yml first"

--- a/.github/workflows/setup-post-mvp-status.yml
+++ b/.github/workflows/setup-post-mvp-status.yml
@@ -32,18 +32,22 @@ jobs:
           set -euo pipefail
 
           # ---- 1. Verifica se l'option Post-MVP esiste già ----
+          # NOTE: GraphQL field(name:) requires name not id. Usiamo fields(first:N)+filter.
           OPTIONS_JSON=$(gh api graphql -f query='
-            query($project: ID!, $field: ID!) {
+            query($project: ID!) {
               node(id: $project) {
                 ... on ProjectV2 {
-                  field(id: $field) {
-                    ... on ProjectV2SingleSelectField {
-                      options { id name }
+                  fields(first: 50) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        options { id name }
+                      }
                     }
                   }
                 }
               }
-            }' -F project="$PROJECT_ID" -F field="$STATUS_FIELD" --jq '.data.node.field.options')
+            }' -F project="$PROJECT_ID" --jq ".data.node.fields.nodes[] | select(.id == \"$STATUS_FIELD\") | .options")
 
           echo "Current Status options:"
           echo "$OPTIONS_JSON"
@@ -82,17 +86,19 @@ jobs:
             # Re-fetch per ottenere il nuovo ID
             sleep 2
             POST_MVP_OPT_ID=$(gh api graphql -f query='
-              query($project: ID!, $field: ID!) {
+              query($project: ID!) {
                 node(id: $project) {
                   ... on ProjectV2 {
-                    field(id: $field) {
-                      ... on ProjectV2SingleSelectField {
-                        options { id name }
+                    fields(first: 50) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id options { id name }
+                        }
                       }
                     }
                   }
                 }
-              }' -F project="$PROJECT_ID" -F field="$STATUS_FIELD" --jq '.data.node.field.options[] | select(.name == "Post-MVP") | .id')
+              }' -F project="$PROJECT_ID" --jq ".data.node.fields.nodes[] | select(.id == \"$STATUS_FIELD\") | .options[] | select(.name == \"Post-MVP\") | .id")
           fi
 
           if [ -z "$POST_MVP_OPT_ID" ] || [ "$POST_MVP_OPT_ID" = "null" ]; then


### PR DESCRIPTION
Quick fix per setup-post-mvp-status.yml + project-status.yml: sostituisco `field(id: $field)` (non supportata dall'API GraphQL di GitHub Projects v2) con `fields(first: 50)` + filter su id locale via jq.