### PR TITLE
fix(ios): align PR 103 device-tested shortcut and Siri triggers

### DIFF
--- a/02_GIGI_APP/GIGI/GIGIApp.swift
+++ b/02_GIGI_APP/GIGI/GIGIApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppIntents
 import GoogleSignIn
 import WebKit
 
@@ -10,6 +11,9 @@ struct GIGIApp: App {
 
     init() {
         GigiDebugLogger.log("GIGIApp init STARTED — bundle=\(Bundle.main.bundleIdentifier ?? "nil")")
+        if #available(iOS 16.0, *) {
+            GigiAppShortcuts.updateAppShortcutParameters()
+        }
         // Synchronous flush attempt for prior crash logs (so they reach the wire
         // before THIS run potentially crashes too).
         let prior = UserDefaults.standard.stringArray(forKey: "gigi_crash_logs") ?? []

--- a/02_GIGI_APP/GIGI/GigiConfig.swift
+++ b/02_GIGI_APP/GIGI/GigiConfig.swift
@@ -49,7 +49,8 @@ enum GigiGateway {
 
 // MARK: - Hardware-trigger Shortcut (Action Button / Back Tap)
 enum GigiHardwareShortcut {
-    static let shortcutName = "Talk to GIGI"
+    static let shortcutName = "gigi-talk-to-gigi-v3"
+    static let displayName = "Talk to GIGI"
 
     // User-provided universal Shortcut link for the May 1 demo path.
     private static let defaultICloudShortcutURL = "https://www.icloud.com/shortcuts/9789dedf6f714f2c8c20b205e815cd2d"

--- a/02_GIGI_APP/GIGI/GigiQuickTalkIntent.swift
+++ b/02_GIGI_APP/GIGI/GigiQuickTalkIntent.swift
@@ -50,7 +50,13 @@ struct GigiAppShortcuts: AppShortcutsProvider {
             phrases: [
                 "Hey \(.applicationName)",
                 "Open \(.applicationName)",
-                "Ask \(.applicationName)"
+                "Ask \(.applicationName)",
+                "Talk to \(.applicationName)",
+                "Start talking with \(.applicationName)",
+                "Start a conversation with \(.applicationName)",
+                "Apri \(.applicationName)",
+                "Chiedi a \(.applicationName)",
+                "Parla con \(.applicationName)"
             ],
             shortTitle: "Open GIGI",
             systemImageName: "mic.fill"

--- a/02_GIGI_APP/GIGI/OnboardingView.swift
+++ b/02_GIGI_APP/GIGI/OnboardingView.swift
@@ -428,7 +428,7 @@ struct OnboardingView: View {
                 // all without the GIGI app ever foregrounding.
                 VStack(alignment: .leading, spacing: 10) {
                     sectionHeader("Step 1 — Build the Talk to GIGI Shortcut", systemImage: "1.circle.fill")
-                    triggerRow(number: "a", title: "Install the Universal Talk to GIGI Shortcut, then open it in Shortcuts if you want to inspect it.")
+                    triggerRow(number: "a", title: "Install the Universal \(GigiHardwareShortcut.displayName) Shortcut. It appears in Shortcuts as \(GigiHardwareShortcut.shortcutName).")
                     triggerRow(number: "b", title: "It loops: Dictate Text → Process speech with GIGI → route markers → repeat until you say stop.")
                     triggerRow(number: "c", title: "CALL: passes the stripped phone number into the native Shortcuts Call action.")
                     triggerRow(number: "d", title: "SMS: sends the stripped message body to the stripped recipient with Send Message.")
@@ -467,15 +467,14 @@ struct OnboardingView: View {
 
                 // ── Setup 2: bind the Shortcut to a hardware trigger ──
                 //
-                // Critical: the picker shows two entries that look almost
-                // identical — the App Shortcut "Open GIGI" (foregrounds the
-                // app) and the user-built Shortcut "Talk to GIGI" (banner
-                // only). We steer the user to the second one explicitly.
+                // Critical: the picker shows both the App Shortcut "Open GIGI"
+                // (foregrounds the app) and the installed hardware Shortcut
+                // (banner only). We steer the user to the installed one.
                 VStack(alignment: .leading, spacing: 10) {
                     sectionHeader("Step 2 — Bind it to your iPhone", systemImage: "2.circle.fill")
                     triggerRow(number: "a", title: "Open the iOS Settings app")
                     triggerRow(number: "b", title: hardwareTriggerPath)
-                    triggerRow(number: "c", title: "Scroll to the Shortcuts section (not App Shortcuts) and pick Talk to GIGI — the one you just built")
+                    triggerRow(number: "c", title: "Scroll to the Shortcuts section (not App Shortcuts) and pick \(GigiHardwareShortcut.shortcutName) — the one you just installed")
 
                     Text("If you accidentally pick \"Open GIGI\" under App Shortcuts, the GIGI app will open instead of the dictation banner. Use the Shortcuts section.")
                         .font(.caption2)
@@ -504,7 +503,7 @@ struct OnboardingView: View {
                 }
                 .padding(.horizontal, 24)
 
-                Text("No setup? Say \"Hey Siri, hey GIGI\" anywhere — works without configuring anything, but the answer comes through Siri.")
+                Text("No setup? Say \"Hey Siri, talk to GIGI\" anywhere — or \"Ehi Siri, parla con GIGI\" on Italian Siri. GIGI opens in conversation mode.")
                     .font(.footnote)
                     .foregroundColor(.white.opacity(0.5))
                     .multilineTextAlignment(.center)
@@ -547,8 +546,8 @@ struct OnboardingView: View {
     }
 
     /// Runs a saved user Shortcut by name. The walkthrough uses this so the
-    /// onboarding "Test the Shortcut" button verifies the user really built
-    /// and saved a Shortcut named "Talk to GIGI" — Shortcuts surfaces a clear
+    /// onboarding "Test the Shortcut" button verifies the user really installed
+    /// the expected Shortcut — Shortcuts surfaces a clear
     /// error sheet if no match is found.
     private func runShortcutByName(_ name: String) {
         #if canImport(UIKit)

--- a/02_GIGI_APP/GIGI/SettingsView.swift
+++ b/02_GIGI_APP/GIGI/SettingsView.swift
@@ -409,7 +409,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Double-tap the back of your iPhone")
                         .font(.subheadline.weight(.semibold))
-                    Text("Bind your custom Talk to GIGI Shortcut (built in onboarding) under Accessibility → Touch → Back Tap → Double Tap → Shortcuts.")
+                    Text("Bind \(GigiHardwareShortcut.shortcutName) under Accessibility → Touch → Back Tap → Double Tap → Shortcuts.")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -422,7 +422,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Action Button (iPhone 15 Pro+)")
                         .font(.subheadline.weight(.semibold))
-                    Text("Settings → Action Button → Shortcut → pick the Talk to GIGI Shortcut you built (NOT the Open GIGI App Shortcut). Its CALL: branch should pass the stripped phone number into Shortcuts' native Call action, so iOS owns the compliant call flow over your current app.")
+                    Text("Settings → Action Button → Shortcut → pick \(GigiHardwareShortcut.shortcutName) (NOT the Open GIGI App Shortcut). Its CALL: branch should pass the stripped phone number into Shortcuts' native Call action, so iOS owns the compliant call flow over your current app.")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -435,7 +435,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Hey Siri")
                         .font(.subheadline.weight(.semibold))
-                    Text("Say \"Hey Siri, hey GIGI\" — opens the app in conversation mode, no setup.")
+                    Text("Say \"Hey Siri, talk to GIGI\" — or \"Ehi Siri, parla con GIGI\" on Italian Siri. GIGI opens in conversation mode.")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }

--- a/docs/runbooks/talk-to-gigi-universal-shortcut.md
+++ b/docs/runbooks/talk-to-gigi-universal-shortcut.md
@@ -1,6 +1,6 @@
 # Talk to GIGI Universal Shortcut
 
-Target Shortcut name: `Talk to GIGI`
+Target Shortcut name: `gigi-talk-to-gigi-v3`
 
 This is the canonical Action Button / Back Tap Shortcut contract for the MVP demo.
 GIGI is the brain: it returns a marker. Shortcuts is the arm: it executes the


### PR DESCRIPTION
## What

Follow-up to merged PR #103. Applies the final device-tested fixes that landed after #103 had already been merged:

- Run the installed Shortcut name gigi-talk-to-gigi-v3 instead of the stale Talk to GIGI executable name.
- Keep Talk to GIGI only as display/user-facing copy where useful.
- Refresh AppIntents shortcut parameters at app startup.
- Add English and Italian Siri phrases verified on physical device.
- Update onboarding/settings/runbook copy to match the tested flow.

## Why

PR #103 was merged after the wake-word de-scope AC pass, but the last physical-device fixes were still local. Without this follow-up, main keeps two broken demo paths: the Test Shortcut button targets a Shortcut name that is not installed, and Siri may not discover the foreground AppIntent phrases on the tested Italian-device setup.

## Test plan

- [x] xcodebuild generic iOS Debug build: BUILD SUCCEEDED
- [x] Physical device: Shortcut now executes the installed gigi-talk-to-gigi-v3 shortcut.
- [x] Physical device: Siri phrase now opens GIGI conversation mode.

Refs #103
Closes #161
Closes #164