### PR TITLE
feat(ios): structured DI logs along transitionToSpeaking → fireDone

### DIFF
--- a/02_GIGI_APP/GIGI/GigiLiveActivityController.swift
+++ b/02_GIGI_APP/GIGI/GigiLiveActivityController.swift
@@ -358,6 +358,7 @@ final class GigiLiveActivityController: ObservableObject {
     /// Pill in `.speaking` while TTS plays. Banner = full response (truncated upstream).
     @MainActor
     func transitionToSpeaking(message: String) async {
+        print("GIGI LiveActivity: transitionToSpeaking ENTER lastPhase=\(lastPhase) activity=\(activity != nil) monitoring=\(monitoringActivity != nil)")
         lastPhase = .speaking
         let displayMessage = normalizedMessage(message, for: .speaking)
         let content = ActivityContent(
@@ -366,14 +367,20 @@ final class GigiLiveActivityController: ObservableObject {
         )
         if let activity {
             await activity.update(content)
+            print("GIGI LiveActivity: transitionToSpeaking EXIT phase=\(lastPhase) activityId=\(activity.id)")
             return
         }
         if monitoringActivity != nil || isMonitoringModeActive {
             await updateMonitoringPill(state: .speaking, message: displayMessage, staleAfter: 60)
+            print("GIGI LiveActivity: transitionToSpeaking EXIT phase=\(lastPhase) activityId=monitoring")
             return
         }
-        guard enabled, let activity else { return }
+        guard enabled, let activity else {
+            print("GIGI LiveActivity: transitionToSpeaking EXIT phase=\(lastPhase) activityId=nil")
+            return
+        }
         await activity.update(content)
+        print("GIGI LiveActivity: transitionToSpeaking EXIT phase=\(lastPhase) activityId=\(activity.id)")
     }
 
     @MainActor

--- a/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
+++ b/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
@@ -257,6 +257,7 @@ class GigiSmartOrchestrator: ObservableObject {
         // T3: pill flips to .speaking with the response banner BEFORE TTS starts so the
         // visual matches the audio. T4: completeWithDone is held back — fireDone() runs
         // after AVSpeechSynthesizer reports didFinish/didCancel via onSpeakingFinished.
+        GigiDebugLogger.voiceEvent("orchestrator.transitionToSpeaking", turnId: currentVoiceTurnId, ["banner.length": "\(banner.count)"])
         Task { await GigiLiveActivityController.shared.transitionToSpeaking(message: banner) }
         scheduleDoneAfterTTS(message: banner)
         speech.speak(trimmed)
@@ -283,7 +284,7 @@ class GigiSmartOrchestrator: ObservableObject {
 
     private func fireDone() {
         guard let msg = pendingDoneMessage else { return }
-        GigiDebugLogger.voiceEvent("orchestrator.fireDone", turnId: currentVoiceTurnId)
+        GigiDebugLogger.voiceEvent("orchestrator.fireDone", turnId: currentVoiceTurnId, ["lastPhase": "\(GigiLiveActivityController.shared.lastPhase)"])
         pendingDoneMessage = nil
         doneSafetyTask?.cancel()
         doneSafetyTask = nil

--- a/02_GIGI_APP/GIGI/GigiSpeechService.swift
+++ b/02_GIGI_APP/GIGI/GigiSpeechService.swift
@@ -87,14 +87,17 @@ final class GigiSpeechService: NSObject {
 
 extension GigiSpeechService: AVSpeechSynthesizerDelegate {
     nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
+        print("GIGI Speech: didStart utterance.length=\(utterance.speechString.count)")
         Task { @MainActor in GigiAudioManager.shared.notifySpeakingStarted() }
     }
     nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        print("GIGI Speech: didFinish utterance.length=\(utterance.speechString.count)")
         Task { @MainActor in GigiAudioManager.shared.notifySpeakingFinished() }
     }
     // didCancel fires when stopSpeaking(at:) is called (barge-in, interruption, etc.).
     // Without this, state stays stuck at .speaking and wake word never resumes.
     nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
+        print("GIGI Speech: didCancel utterance.length=\(utterance.speechString.count)")
         Task { @MainActor in GigiAudioManager.shared.notifySpeakingFinished() }
     }
 }


### PR DESCRIPTION
Closes #38

## What
Adds structured logging along the `transitionToSpeaking → speak → notifySpeakingFinished → onSpeakingFinished → fireDone → completeWithDone` chain. Entry/exit prints in `GigiLiveActivityController.transitionToSpeaking`, utterance length logs in `GigiSpeechService` delegate callbacks, `orchestrator.transitionToSpeaking` event with `banner.length`, and `lastPhase` in the `fireDone` payload.

## Why
Baseline telemetry to prove the `.thinking → .speaking → .done` sequence is complete during smoke tests. Without these probes, sub-issues 2/4 and 3/4 of #10 cannot demonstrate behavior fixes. Telemetry-only, no logic change.

## Test plan
- [ ] AC #1 verified by PM on physical device (Console.app shows full sequence during talking turn)
- [ ] Build verify: pending

⚠️ **AC pending PM verification — review-only PR, do not merge until AC checked**
⚠️ **Build verify SKIPPED — run on review**

Implementato da PM in batch session