### PR TITLE
feat(ios): bannerForPill helper — word boundary trim + emoji guard

### DIFF
--- a/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
+++ b/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
@@ -243,9 +243,7 @@ class GigiSmartOrchestrator: ObservableObject {
         }
 
         let trimmed = result.speech.trimmingCharacters(in: .whitespacesAndNewlines)
-        let banner = trimmed.isEmpty
-            ? "Fatto."
-            : (trimmed.count <= 100 ? trimmed : String(trimmed.prefix(97)) + "…")
+        let banner = trimmed.isEmpty ? "Fatto." : Self.bannerForPill(speech: trimmed)
 
         // T5: empty speech path. Skip TTS (avoids `speak("")` → empty AVSpeech buffer
         // → mDataByteSize=0 noise), close the pill straight away.
@@ -459,6 +457,25 @@ class GigiSmartOrchestrator: ObservableObject {
     }
 
     // MARK: - Helpers
+
+    /// Formats a TTS speech string into a Live Activity pill banner: trims to last
+    /// word boundary under 80 chars, strips emoji presentation scalars (ActivityKit
+    /// renders some multi-codepoint emoji incorrectly), falls back to "Speaking…"
+    /// if the cleaned text is too short.
+    static func bannerForPill(speech: String) -> String {
+        let cleaned = speech
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .unicodeScalars
+            .filter { !$0.properties.isEmojiPresentation && !($0.value >= 0x1F300 && $0.value <= 0x1FAFF) }
+            .reduce(into: "") { $0.append(Character($1)) }
+        guard cleaned.count >= 2 else { return "Speaking…" }
+        guard cleaned.count > 80 else { return cleaned }
+        let cap = cleaned.prefix(80)
+        if let lastSpace = cap.lastIndex(of: " ") {
+            return String(cap[..<lastSpace]) + "…"
+        }
+        return String(cap) + "…"
+    }
 
     /// Splits a text containing multiple sequential commands into individual parts.
     /// Returns nil if only one command is detected (avoids false splits like "call mom and dad").


### PR DESCRIPTION
Closes #39

## What
Extracts pill banner formatting into static helper bannerForPill(speech:). Trims to last word boundary under 80 chars, strips emoji presentation scalars, falls back to Speaking… when text < 2 chars.

## Why
Old inline trim cut words mid-stream (Sto pensando alla nost) and ActivityKit rendered some multi-codepoint emoji incorrectly. Replaces inline truncation in handleResult.

## Test plan
- [ ] AC #1 verified by PM: pill banner shows clean word-boundary text
- [ ] Build verify: pending

⚠️ AC pending PM verification — review-only PR
⚠️ Build verify SKIPPED — run on review

Implementato da PM in batch session