### PR TITLE
fix(ios): barge-in pill flips to .listening before audio settle

### DIFF
--- a/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
+++ b/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
@@ -406,6 +406,10 @@ class GigiSmartOrchestrator: ObservableObject {
         clearPendingDone(reason: "bargeIn.\(source)")
         GigiDebugLogger.voiceEvent("orchestrator.interruptAndListen", turnId: turnId, ["source": source, "audioState": "\(GigiAudioManager.shared.state)"])
 
+        // Flip pill to .listening FIRST so user sees state change within 500ms,
+        // independent of audio engine settle time below.
+        Task { await GigiLiveActivityController.shared.beginListening() }
+
         SoundEngine.play(.wakeWord)
         if isQuickTalkSession { onQuickTalkStateChange?(.listening) }
 
@@ -421,7 +425,6 @@ class GigiSmartOrchestrator: ObservableObject {
             speech.stopSpeaking()
             GigiAudioManager.shared.startRecording()
         }
-        Task { await GigiLiveActivityController.shared.beginListening() }
     }
 
     func stopMicCapture() {


### PR DESCRIPTION
Closes #40

## What
Reorders interruptAndListen so beginListening() pill update is dispatched FIRST, before audio engine start/stop. Ensures pill state reflects user perception within 500ms of barge-in instead of waiting for audio settle.

## Why
Old order: clearPendingDone → audio start/stop → beginListening. The audio settle could delay pill flip up to safety timer (8s), leaving user looking at .speaking while actually being recorded.

clearPendingDone and beginListening were already wired correctly (verified at lines 406, 424). This PR just reorders for visual responsiveness.

## Test plan
- [ ] AC #1 verified by PM: pill flips to .listening within 500ms during barge-in
- [ ] AC #2 verified: Console.app shows clearPendingDone reason=bargeIn.realtime
- [ ] Build verify: pending

⚠️ AC pending PM verification — review-only PR
⚠️ Build verify SKIPPED — run on review

Implementato da PM in batch session