### PR TITLE
feat(ios): draft message preview sheet — send/edit/cancel UI

### DIFF
--- a/02_GIGI_APP/GIGI/ChatView.swift
+++ b/02_GIGI_APP/GIGI/ChatView.swift
@@ -63,6 +63,31 @@ struct ChatView: View {
                     .padding(.top, 56)
                     .zIndex(99)
             }
+
+            #if DEBUG
+            // Draft preview debug trigger (#47 AC verification — remove once #171 wires the real route)
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    Button {
+                        gigi.presentDraft(
+                            contact: "Fede",
+                            platform: "whatsapp",
+                            body: "Hey Fede! Can I drop by at 4pm today? 🙌",
+                            raw: "can i come at 4pm today"
+                        )
+                    } label: {
+                        Image(systemName: "ladybug.fill")
+                            .padding(10)
+                            .background(Circle().fill(Color.purple.opacity(0.85)))
+                            .foregroundColor(.white)
+                    }
+                    .padding(.trailing, 16)
+                    .padding(.bottom, 96)
+                }
+            }
+            #endif
         }
         .animation(.easeInOut(duration: 0.25), value: gigi.bannerMessage)
         .animation(.easeInOut(duration: 0.2), value: memory.messages.count)

--- a/02_GIGI_APP/GIGI/ChatView.swift
+++ b/02_GIGI_APP/GIGI/ChatView.swift
@@ -66,6 +66,9 @@ struct ChatView: View {
         }
         .animation(.easeInOut(duration: 0.25), value: gigi.bannerMessage)
         .animation(.easeInOut(duration: 0.2), value: memory.messages.count)
+        .sheet(isPresented: $gigi.showDraftPreview) {
+            DraftMessagePreviewSheet()
+        }
     }
 
     // MARK: - Sub-views

--- a/02_GIGI_APP/GIGI/DraftMessagePreviewSheet.swift
+++ b/02_GIGI_APP/GIGI/DraftMessagePreviewSheet.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Send/Edit/Cancel preview sheet for draft messages (#47).
+/// Shown above ChatView when GigiSmartOrchestrator publishes pendingDraft.
+struct DraftMessagePreviewSheet: View {
+    @ObservedObject var orchestrator = GigiSmartOrchestrator.shared
+    @State private var editedBody: String = ""
+    @State private var isEditing = false
+    @FocusState private var bodyFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 16) {
+                if let d = orchestrator.pendingDraft {
+                    HStack {
+                        Text("To: \(d.contact)")
+                            .font(.headline)
+                        Spacer()
+                        Text(d.platform.capitalized)
+                            .font(.caption)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                            .background(Capsule().fill(Color.green.opacity(0.2)))
+                    }
+
+                    TextEditor(text: $editedBody)
+                        .focused($bodyFocused)
+                        .frame(minHeight: 120)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                        )
+                        .disabled(!isEditing)
+
+                    HStack(spacing: 12) {
+                        Button(role: .destructive) {
+                            orchestrator.cancelDraft()
+                        } label: {
+                            Text("Cancel").frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button {
+                            isEditing.toggle()
+                            bodyFocused = isEditing
+                        } label: {
+                            Text(isEditing ? "Done" : "Edit").frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button {
+                            orchestrator.pendingDraft?.body = editedBody
+                            Task { _ = await orchestrator.sendDraft() }
+                        } label: {
+                            Text("Send").frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .padding(.top, 8)
+
+                    Spacer()
+                }
+            }
+            .padding()
+            .navigationTitle("Draft preview")
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                editedBody = orchestrator.pendingDraft?.body ?? ""
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}

--- a/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
+++ b/02_GIGI_APP/GIGI/GigiSmartOrchestrator.swift
@@ -24,6 +24,41 @@ class GigiSmartOrchestrator: ObservableObject {
     @Published var bannerMessage   = ""
     @Published var showGatewayInstallPrompt = false
 
+    // MARK: - Draft preview (Sub #47 — WhatsApp/iMessage draft Send/Edit/Cancel sheet)
+
+    struct PendingDraft: Equatable {
+        let contact: String
+        let platform: String  // "whatsapp", "imessage"
+        var body: String
+        let raw: String       // pre-enrichment, for "show original"
+    }
+    @Published var showDraftPreview: Bool = false
+    @Published var pendingDraft: PendingDraft?
+
+    func presentDraft(contact: String, platform: String, body: String, raw: String) {
+        pendingDraft = PendingDraft(contact: contact, platform: platform, body: body, raw: raw)
+        showDraftPreview = true
+    }
+
+    @discardableResult
+    func sendDraft() async -> String {
+        guard let d = pendingDraft else { return "no draft" }
+        print("DRAFT MOCK SEND: to=\(d.contact) platform=\(d.platform) body.length=\(d.body.count)")
+        speech.speak("Sent to \(d.contact).")
+        memory.addGigi("Sent to \(d.contact) on \(d.platform.capitalized): \"\(d.body)\"")
+        showDraftPreview = false
+        pendingDraft = nil
+        return "Sent (mock) to \(d.contact)."
+    }
+
+    func cancelDraft() {
+        guard let d = pendingDraft else { return }
+        speech.speak("Cancelled.")
+        memory.addGigi("Draft to \(d.contact) cancelled.")
+        showDraftPreview = false
+        pendingDraft = nil
+    }
+
     // MARK: - Dependencies
 
     private let agentEngine  = GigiAgentEngine.shared


### PR DESCRIPTION
Closes #47

## What
- New `DraftMessagePreviewSheet` SwiftUI view shown above ChatView via .sheet
- `PendingDraft` struct + `presentDraft / sendDraft / cancelDraft` methods on `GigiSmartOrchestrator`
- Send: log mock + TTS "Sent to <contact>" + chat bubble
- Cancel: TTS "Cancelled" + chat bubble
- Edit toggles TextEditor focus, edited body propagates to `pendingDraft.body` before send
- DEBUG-only ladybug FAB in ChatView triggers `presentDraft` for AC verification (removable after #171)

## Test plan — ALL VERIFIED on iPhone 17 Pro
- [x] AC1: tap debug ladybug → sheet appears with "To: Fede" / "Whatsapp" badge / preset body
- [x] AC2: Edit → TextEditor editable, body modifiable
- [x] AC3: Send → sheet dismisses, ChatView bubble "Sent to Fede on Whatsapp: ..."
- [x] AC4: Cancel → sheet dismisses, bubble "Draft to Fede cancelled."
- [x] AC5: edited body before Send is reflected in final pendingDraft
- [x] AC6: BUILD SUCCEEDED on iOS generic
- [x] Bonus: nothing opens in WhatsApp / Safari (mock-only)

## Rebase note
Branch was rebased on `main` (post #169 merge) to bring in `GigiToneEnrichment` and other concurrent merges. Force-push with lease performed.

## Follow-up
- After #171 merges (route through dispatcher), debug ladybug can be removed
- Sub 3/4 (#48) wires `send_message` / `web_whatsapp` tools to `presentDraft`
- Sub 4/4 (#49) adds voice confirm during preview