### PR TITLE
feat(ios): route send_message and web_whatsapp through draft preview

### DIFF
--- a/02_GIGI_APP/GIGI/ChatView.swift
+++ b/02_GIGI_APP/GIGI/ChatView.swift
@@ -65,23 +65,45 @@ struct ChatView: View {
             }
 
             #if DEBUG
-            // Draft preview debug trigger (#47 AC verification — remove once #171 wires the real route)
+            // Debug FABs:
+            //  📨 envelope → dispatcher.executeNative(send_message) end-to-end (#48 route)
+            //  🐞 ladybug  → directly call presentDraft (#47 sheet UI in isolation)
             VStack {
                 Spacer()
                 HStack {
                     Spacer()
-                    Button {
-                        gigi.presentDraft(
-                            contact: "Fede",
-                            platform: "whatsapp",
-                            body: "Hey Fede! Can I drop by at 4pm today? 🙌",
-                            raw: "can i come at 4pm today"
-                        )
-                    } label: {
-                        Image(systemName: "ladybug.fill")
-                            .padding(10)
-                            .background(Circle().fill(Color.purple.opacity(0.85)))
-                            .foregroundColor(.white)
+                    VStack(spacing: 12) {
+                        Button {
+                            Task {
+                                let result = await GigiActionDispatcher.shared.executeNative(
+                                    "send_message",
+                                    args: [
+                                        "contact": "Fede",
+                                        "message": "can i come at 4 pm today?",
+                                        "platform": "whatsapp"
+                                    ]
+                                )
+                                print("DEBUG[#48] dispatcher → \(result)")
+                            }
+                        } label: {
+                            Image(systemName: "envelope.badge")
+                                .padding(10)
+                                .background(Circle().fill(Color.orange.opacity(0.85)))
+                                .foregroundColor(.white)
+                        }
+                        Button {
+                            gigi.presentDraft(
+                                contact: "Fede",
+                                platform: "whatsapp",
+                                body: "Hey Fede! Can I drop by at 4pm today? 🙌",
+                                raw: "can i come at 4pm today"
+                            )
+                        } label: {
+                            Image(systemName: "ladybug.fill")
+                                .padding(10)
+                                .background(Circle().fill(Color.purple.opacity(0.85)))
+                                .foregroundColor(.white)
+                        }
                     }
                     .padding(.trailing, 16)
                     .padding(.bottom, 96)

--- a/02_GIGI_APP/GIGI/ChatView.swift
+++ b/02_GIGI_APP/GIGI/ChatView.swift
@@ -78,7 +78,7 @@ struct ChatView: View {
                                 let result = await GigiActionDispatcher.shared.executeNative(
                                     "send_message",
                                     args: [
-                                        "contact": "Fede",
+                                        "contact": "Edi",
                                         "message": "can i come at 4 pm today?",
                                         "platform": "whatsapp"
                                     ]

--- a/02_GIGI_APP/GIGI/GigiActionDispatcher+Native.swift
+++ b/02_GIGI_APP/GIGI/GigiActionDispatcher+Native.swift
@@ -79,20 +79,27 @@ extension GigiActionDispatcher {
             let result = await bridge.makeCallAutomatic(to: contact)
             return .success(result)
 
-        case "send_message":
+        case "send_message", "send_whatsapp":
             guard !contact.isEmpty else { return .failure("contact parameter required") }
             let body = string(args, "message", fallback: string(args, "body"))
             guard !body.isEmpty else { return .failure("message parameter required") }
-            let platform = string(args, "platform", fallback: "imessage")
-            let result = await bridge.sendMessageAutomatic(to: contact, body: body, platform: platform)
-            return .success(result)
+            let platform = name == "send_whatsapp"
+                ? "whatsapp"
+                : string(args, "platform", fallback: "imessage")
 
-        case "send_whatsapp":
-            guard !contact.isEmpty else { return .failure("contact parameter required") }
-            let body = string(args, "message", fallback: string(args, "body"))
-            guard !body.isEmpty else { return .failure("message parameter required") }
-            let result = await bridge.sendMessageAutomatic(to: contact, body: body, platform: "whatsapp")
-            return .success(result)
+            // Sub #12 — route through draft preview instead of automatic send.
+            // 1) tone enrichment (Apple Intelligence on-device → cloud fallback)
+            let enriched = await GigiToneEnrichment.shared.enrich(rawDraft: body, contactName: contact)
+            // 2) present preview sheet — user confirms tap-by-tap
+            await MainActor.run {
+                GigiSmartOrchestrator.shared.presentDraft(
+                    contact: contact,
+                    platform: platform,
+                    body: enriched,
+                    raw: body
+                )
+            }
+            return .success("I drafted a message to \(contact). Check the preview to send or edit.")
 
         case "send_email":
             guard !contact.isEmpty else { return .failure("contact parameter required") }

--- a/02_GIGI_APP/GIGI/GigiActionDispatcher+Web.swift
+++ b/02_GIGI_APP/GIGI/GigiActionDispatcher+Web.swift
@@ -34,6 +34,20 @@ extension GigiActionDispatcher {
         guard !contact.isEmpty else { return .failure("contact parameter required for web_whatsapp") }
         guard !message.isEmpty else { return .failure("message parameter required for web_whatsapp") }
 
+        // Sub #12 — route through draft preview before WhatsApp Web automation.
+        let enriched = await GigiToneEnrichment.shared.enrich(rawDraft: message, contactName: contact)
+        await MainActor.run {
+            GigiSmartOrchestrator.shared.presentDraft(
+                contact: contact,
+                platform: "whatsapp",
+                body: enriched,
+                raw: message
+            )
+        }
+        return .success("I drafted a WhatsApp message to \(contact). Check the preview to send or edit.", tokenEstimate: 20)
+
+        // Legacy direct-send path retained below for reference (#12 path now interrupts before this).
+        #if false
         let result = await GigiWebAgent.shared.sendWhatsAppResult(contact: contact, message: message)
         switch result {
         case .success:
@@ -58,6 +72,7 @@ extension GigiActionDispatcher {
             }
             return .failure("WhatsApp Web failed: \(reason)")
         }
+        #endif
     }
 
     // MARK: - Restaurant booking

--- a/02_GIGI_APP/GIGI/GigiToneEnrichment.swift
+++ b/02_GIGI_APP/GIGI/GigiToneEnrichment.swift
@@ -34,15 +34,21 @@ final class GigiToneEnrichment {
     private static let dedicatedInstructions: String = """
     \(Preferences.warmCasual)
 
+    The recipient name is provided per-request as "To:". Address them by that
+    exact name — never substitute the example names below.
+
     Examples:
+    To: Marco
     Raw: posso passare alle 18 oggi
-    Rewritten: Ciao Fede! Posso passare alle 18 oggi? 😊
+    Rewritten: Ciao Marco! Posso passare alle 18 oggi? 😊
 
+    To: Sarah
     Raw: can i come at 4 pm today
-    Rewritten: Hey Fede, can I drop by at 4pm today? 🙌
+    Rewritten: Hey Sarah, can I drop by at 4pm today? 🙌
 
+    To: Tom
     Raw: meeting tomorrow 9am ok
-    Rewritten: Hey, 9am tomorrow works for me 👍
+    Rewritten: Hey Tom, 9am tomorrow works for me 👍
     """
 
     @available(iOS 18.1, *)
@@ -57,7 +63,7 @@ final class GigiToneEnrichment {
         let trimmed = rawDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return trimmed }
 
-        let userInput = "Raw: \(trimmed)\nRewritten:"
+        let userInput = "To: \(contactName)\nRaw: \(trimmed)\nRewritten:"
 
         // Path 1 — Apple Intelligence on-device (dedicated session, free-form output)
         #if canImport(FoundationModels)

--- a/02_GIGI_APP/GIGI/GigiToolRegistry.swift
+++ b/02_GIGI_APP/GIGI/GigiToolRegistry.swift
@@ -115,7 +115,7 @@ struct MakeCallTool: GigiTool {
 
 struct SendMessageTool: GigiTool {
     let name = "send_message"
-    let requiresConfirmation = false
+    let requiresConfirmation = true
     let tags = ["message", "text", "sms", "imessage", "whatsapp", "telegram", "manda", "scrivi", "messaggio"]
 
     let declaration = FunctionDeclaration(
@@ -926,7 +926,7 @@ struct SearchGroupsTool: GigiTool {
 
 struct WebWhatsAppTool: GigiTool {
     let name = "web_whatsapp"
-    let requiresConfirmation = false
+    let requiresConfirmation = true
     let tags = ["whatsapp", "wa", "whatsapp web", "messaggio whatsapp"]
 
     let declaration = FunctionDeclaration(


### PR DESCRIPTION
Closes #48
Refs #46 (in-pr fix for contact-name leak in tone enrichment few-shot)

## What
- `send_message` and `send_whatsapp` cases in the native dispatcher now run `enrich → presentDraft` instead of `bridge.sendMessageAutomatic`
- `web_whatsapp` case in the web dispatcher routes through the same draft preview path; legacy direct-send fenced under `#if false` for reference
- `SendMessageTool` and `WebWhatsAppTool` flipped to `requiresConfirmation = true`
- Bonus fix: `GigiToneEnrichment` now passes `contactName` into the LLM template (was leaking few-shot 'Fede' regardless of recipient)
- DEBUG-only orange envelope FAB in ChatView triggers `executeNative("send_message")` end-to-end so the route can be verified without harness/wake/LLM

## Test plan — ALL VERIFIED on iPhone 17 Pro
- [x] AC1: tap envelope FAB → `bridge.sendMessageAutomatic` is NOT called (console grep clean)
- [x] AC2: `DraftMessagePreviewSheet` appears with body enriched (recipient name correct after the few-shot fix)
- [x] AC3: dispatcher returns success message; sheet handles user-facing flow
- [x] AC4: tap Send → ChatView bubble "Sent to <X> on Whatsapp: ..." + TTS "Sent to <X>"
- [x] AC5: tap Cancel → bubble "Draft to <X> cancelled." + TTS "Cancelled"
- [x] AC6: BUILD SUCCEEDED on iOS generic

## Rebase note
Branch was rebased on `main` (post #169 + #170 merges) to bring in `GigiToneEnrichment` and `presentDraft`. Force-push with lease performed.

## Follow-up
- Sub 4/4 (#49) adds voice confirm during preview
- Debug envelope + ladybug FABs are `#if DEBUG`-gated; can be removed once full voice → wake → LLM flow is wired end-to-end