### PR TITLE
feat(ios): wire GigiTaskExtractor to PresenceSessionController

### DIFF
--- a/02_GIGI_APP/GIGI/GigiConversationMemory.swift
+++ b/02_GIGI_APP/GIGI/GigiConversationMemory.swift
@@ -57,6 +57,16 @@ final class GigiConversationMemory: ObservableObject {
         trimIfNeeded()
     }
 
+    /// Last `turns` user transcripts joined as a bulletted multi-line string.
+    /// Used by GigiTaskExtractor periodic trigger (#54).
+    func recentUserTranscript(turns: Int = 6) -> String {
+        messages
+            .filter { $0.role == .user }
+            .suffix(turns)
+            .map { "- \($0.text)" }
+            .joined(separator: "\n")
+    }
+
     func addThinking() -> UUID {
         let msg = GigiMessage(role: .gigi, text: "", isThinking: true)
         messages.append(msg)

--- a/02_GIGI_APP/GIGI/GigiConversationMemory.swift
+++ b/02_GIGI_APP/GIGI/GigiConversationMemory.swift
@@ -43,6 +43,12 @@ final class GigiConversationMemory: ObservableObject {
     private let tokenBudget     = 8_000
     private let toolResultLimit = 500   // chars before truncation
 
+    // #54 — periodic task extraction trigger (every 2 user turns).
+    // Lives here (not in PresenceSessionController) so it fires for every user turn
+    // — voice or chat — independent of Presence Mode (post-MVP).
+    private var taskExtractionTurnCounter = 0
+    private var taskExtractionTask: Task<Void, Never>?
+
     private init() {
         // Auto-restore recent session on launch
         if let restored = loadIfRecentSession() {
@@ -55,6 +61,17 @@ final class GigiConversationMemory: ObservableObject {
     func addUser(_ text: String) {
         messages.append(GigiMessage(role: .user, text: text))
         trimIfNeeded()
+
+        // #54 — fire task extraction every 2 user turns. Cancel any in-flight
+        // extractor task so we never have two extracts racing on the same memory.
+        taskExtractionTurnCounter += 1
+        if taskExtractionTurnCounter % 2 == 0 {
+            taskExtractionTask?.cancel()
+            let transcript = recentUserTranscript(turns: 6)
+            taskExtractionTask = Task {
+                await GigiTaskExtractor.shared.extract(from: transcript)
+            }
+        }
     }
 
     /// Last `turns` user transcripts joined as a bulletted multi-line string.

--- a/02_GIGI_APP/GIGI/PresenceSessionController.swift
+++ b/02_GIGI_APP/GIGI/PresenceSessionController.swift
@@ -53,10 +53,6 @@ final class PresenceSessionController: ObservableObject {
     private var durationTask: Task<Void, Never>?
     private var standaloneMuted = false
 
-    // #54 — periodic task extraction during Talking Session
-    private var turnCounter: Int = 0
-    private var extractionTask: Task<Void, Never>?
-
     private init() {
         GigiDebugLogger.log("PresenceSessionController init START")
         observeOrchestrator()
@@ -151,11 +147,6 @@ final class PresenceSessionController: ObservableObject {
 
         inactivityTask?.cancel()
         durationTask?.cancel()
-        // #54 — clean up task extractor state
-        extractionTask?.cancel()
-        extractionTask = nil
-        turnCounter = 0
-        Task { await GigiTaskExtractor.shared.clear() }
         GigiAudioManager.shared.stopAll()
 
         Task {
@@ -301,17 +292,6 @@ final class PresenceSessionController: ObservableObject {
                 self.lastTranscript = text
                 self.state = .thinking
                 await GigiLiveActivityController.shared.updatePresence(state: .thinking, message: "Thinking about it", transcript: text)
-
-                // #54 — fire task extraction every 2 user turns. Cancel any in-flight
-                // extractor task so we never have two extracts racing on the same memory.
-                self.turnCounter += 1
-                if self.turnCounter % 2 == 0 {
-                    self.extractionTask?.cancel()
-                    self.extractionTask = Task {
-                        let transcript = await GigiConversationMemory.shared.recentUserTranscript(turns: 6)
-                        await GigiTaskExtractor.shared.extract(from: transcript)
-                    }
-                }
             }
         }
     }

--- a/02_GIGI_APP/GIGI/PresenceSessionController.swift
+++ b/02_GIGI_APP/GIGI/PresenceSessionController.swift
@@ -53,6 +53,10 @@ final class PresenceSessionController: ObservableObject {
     private var durationTask: Task<Void, Never>?
     private var standaloneMuted = false
 
+    // #54 — periodic task extraction during Talking Session
+    private var turnCounter: Int = 0
+    private var extractionTask: Task<Void, Never>?
+
     private init() {
         GigiDebugLogger.log("PresenceSessionController init START")
         observeOrchestrator()
@@ -147,6 +151,11 @@ final class PresenceSessionController: ObservableObject {
 
         inactivityTask?.cancel()
         durationTask?.cancel()
+        // #54 — clean up task extractor state
+        extractionTask?.cancel()
+        extractionTask = nil
+        turnCounter = 0
+        Task { await GigiTaskExtractor.shared.clear() }
         GigiAudioManager.shared.stopAll()
 
         Task {
@@ -292,6 +301,17 @@ final class PresenceSessionController: ObservableObject {
                 self.lastTranscript = text
                 self.state = .thinking
                 await GigiLiveActivityController.shared.updatePresence(state: .thinking, message: "Thinking about it", transcript: text)
+
+                // #54 — fire task extraction every 2 user turns. Cancel any in-flight
+                // extractor task so we never have two extracts racing on the same memory.
+                self.turnCounter += 1
+                if self.turnCounter % 2 == 0 {
+                    self.extractionTask?.cancel()
+                    self.extractionTask = Task {
+                        let transcript = await GigiConversationMemory.shared.recentUserTranscript(turns: 6)
+                        await GigiTaskExtractor.shared.extract(from: transcript)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #54

## What
- New `recentUserTranscript(turns:)` helper in `GigiConversationMemory` returning the last N user turns as a bulleted multi-line string
- Task-extract trigger moved into `GigiConversationMemory.addUser(_:)` itself: every 2 user turns, cancels any in-flight extract Task and schedules a new one with the recent transcript
- `PresenceSessionController` reverted: no longer owns the extract trigger (removed turnCounter, extractionTask, stopSession cleanup, observeOrchestrator hook)

## Why
Presence Mode is post-MVP (sub-issues #41-#45 carry `post-mvp` label). Wiring the trigger inside `PresenceSessionController.observeOrchestrator` meant the extractor only ran when 'GIGI always available' was ON — for MVP demo flow (chat + voice without Presence) it never fired. Moving the trigger into `GigiConversationMemory.addUser` makes it fire for **every** user turn regardless of input modality (voice via `GigiSmartOrchestrator -> memory.addUser`, chat via UI -> `memory.addUser`). Strategy A from session 2026-05-04: lifecycle-less, list accumulates until app restart.

## Test plan — verified on iPhone 17 Pro by @fc200490-sketch (2026-05-04)
- [x] AC1: app launches on device, no crash
- [x] AC2: turn 1 (`Devo rispondere a Fede`) → GIGI replies, console shows NO extract call (counter=1)
- [x] AC3: turn 2 (`And prepare for the 3 pm meeting`) → console: `GigiTaskExtractor extracted 2 raw, total 2 after dedup` ✅
- [x] AC4: GIGI TTS fluent during extract Task (verified on turn 4, dev confirmed no stutter)
- [x] AC5: turn 3 (`What time is it`) → no extract (counter=3, % 2 ≠ 0)
- [x] AC6: turn 4 (`Remind me to call mamma`) → console: `GigiTaskExtractor extracted 3 raw, total 3 after dedup` ✅
- [x] Build verify: `BUILD SUCCEEDED` (xcodebuild generic/platform=iOS via SSH on Mac)

## Step Report
**Cosa abbiamo implementato**: il trigger di task extraction vive ora in `GigiConversationMemory.addUser` invece che in `PresenceSessionController`. Significa: ogni 2 turni utente parte un extract in background `Task`, indipendente da Presence Mode (post-MVP). Il counter è una proprietà privata di `GigiConversationMemory`, lifecycle-less (la lista accumula fino a kill app — strategia A).

**Cosa è ora possibile**: la sub 3/3 di #14 (PR #141) può wirearsi alla lista `GigiTaskExtractor.shared.tasks` accumulata da questi extract per renderla visibile in UI. Parent #14 passa da 33% a 66%.

**Prossimo passo**: rebase + merge di PR #141 (sub 3/3 #55) per chiudere parent #14 al 100%.

## Notes
- AC verified on real device (iPhone 17 Pro) via Run-from-Xcode + console filter `GigiTaskExtractor`
- Refactored after E2E test session — original wiring (in `PresenceSessionController`) was technically correct but functionally dead-code given Presence is post-MVP
- Admin merge requested by @fc200490-sketch — strada A scope confirmed in session 2026-05-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)