### PR TITLE
feat(ios): TalkingSessionTaskListView live overlay during Presence

### DIFF
--- a/02_GIGI_APP/GIGI/ChatView.swift
+++ b/02_GIGI_APP/GIGI/ChatView.swift
@@ -63,6 +63,18 @@ struct ChatView: View {
                     .padding(.top, 56)
                     .zIndex(99)
             }
+
+            // ── Live task list overlay (Talking Session only) — Sub #55 ──────
+            if presence.isActive {
+                HStack {
+                    Spacer()
+                    TalkingSessionTaskListView()
+                        .padding(.top, 120)
+                        .padding(.trailing, 12)
+                }
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+                .zIndex(50)
+            }
         }
         .animation(.easeInOut(duration: 0.25), value: gigi.bannerMessage)
         .animation(.easeInOut(duration: 0.2), value: memory.messages.count)

--- a/02_GIGI_APP/GIGI/TalkingSessionTaskListView.swift
+++ b/02_GIGI_APP/GIGI/TalkingSessionTaskListView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Live task list overlay shown alongside ChatView during Talking Session.
+/// Reflects GigiTaskExtractor.shared.tasks in real time (#55).
+struct TalkingSessionTaskListView: View {
+    @ObservedObject var extractor = GigiTaskExtractor.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "checklist")
+                    .foregroundStyle(.cyan)
+                Text("Tasks")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
+                Spacer()
+                if extractor.isExtracting {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .tint(.cyan)
+                }
+            }
+
+            if extractor.tasks.isEmpty {
+                Text("Listening for tasks…")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.4))
+                    .italic()
+            } else {
+                ForEach(extractor.tasks) { task in
+                    HStack(alignment: .top, spacing: 6) {
+                        Image(systemName: "circle")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.white.opacity(0.5))
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(task.title)
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.white)
+                            if let dl = task.deadline, !dl.isEmpty {
+                                Text(dl)
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.orange.opacity(0.8))
+                            }
+                            if let vip = task.vipContact, !vip.isEmpty {
+                                Text("⭐ \(vip)")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.yellow)
+                            }
+                        }
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .trailing)))
+                }
+            }
+        }
+        .padding(10)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .frame(maxWidth: 200)
+        .animation(.easeInOut(duration: 0.25), value: extractor.tasks.count)
+    }
+}


### PR DESCRIPTION
Closes #55

## What
- New TalkingSessionTaskListView SwiftUI view binding to GigiTaskExtractor.shared
- Shows checklist icon, task rows with title/deadline/VIP badge, isExtracting spinner
- 'Listening for tasks…' placeholder when empty
- Embedded as right-side overlay in ChatView, conditional on presence.isActive
- Fade+slide transition on count change

## Test plan
- [ ] AC verified by PM on device
- [ ] Build verify pending — TalkingSessionTaskListView.swift needs Xcode target add

⚠️ AC pending PM verification — review-only PR
⚠️ Build verify SKIPPED

Implementato da PM in batch session