### PR TITLE
docs(qa): T1.1-T1.3 + T6.1-T6.2 evidence skeletons

### DIFF
--- a/docs/qa-evidence/2026-04-30/T1.1-onboarding-cold.md
+++ b/docs/qa-evidence/2026-04-30/T1.1-onboarding-cold.md
@@ -1,0 +1,33 @@
+# T1.1 — Cold-start Onboarding Evidence
+
+**Status:** ⏳ Pending PM execution on iPhone 14 Pro backup device
+**Issue:** #68 (Sub #17 · 5/7)
+**Date executed:** _to be filled_
+**Tester:** Armando Battaglino (PM)
+
+## Pre-condition
+
+- [ ] iPhone 14 Pro backup device, signed out of iCloud GIGI container
+- [ ] App deleted from device
+- [ ] Fresh paid-signed IPA from CI
+
+## Steps
+
+1. Install IPA via 3uTools
+2. Launch app — observe time-to-first-screen
+3. Welcome screen visible (step 1)
+
+## Acceptance Criteria
+
+- [ ] AC1: cold start does not crash
+- [ ] AC1: onboarding step 1 visible within 3s of launch
+
+## Notes
+
+- Time to first screen (s): _to be filled_
+- Crash log (if any): _to be filled_
+
+## Evidence
+
+- [ ] Screen recording attached: _link_
+

--- a/docs/qa-evidence/2026-04-30/T1.2-T1.3-api-keys.md
+++ b/docs/qa-evidence/2026-04-30/T1.2-T1.3-api-keys.md
@@ -1,0 +1,43 @@
+# T1.2 + T1.3 — API Key Onboarding Evidence
+
+**Status:** ⏳ Pending PM execution
+**Issue:** #68
+**Date executed:** _to be filled_
+
+## T1.2 — Groq API key
+
+### Steps
+1. Onboarding step 2 reached
+2. Paste valid Groq key
+3. Tap "Test"
+
+### AC
+- [ ] AC2: Test connection green ✓
+- [ ] AC2: Key persists after app restart
+
+### Evidence
+- [ ] Screen recording: _link_
+- [ ] Log snippet showing key written to Keychain (no plaintext): _link_
+
+## T1.3 — Gemini API key
+
+### Steps
+1. Onboarding step 3 reached
+2. Paste valid Gemini key
+3. Tap "Test"
+
+### AC
+- [ ] AC3: Test connection green ✓
+- [ ] AC3: Key persists after app restart
+
+### Evidence
+- [ ] Screen recording: _link_
+- [ ] Log snippet (no plaintext): _link_
+
+## Security spot check (AC6)
+
+Inspect exported app logs after onboarding completes:
+
+- [ ] Grep for first 8 chars of Groq key prefix `gsk_` → MUST NOT appear
+- [ ] Grep for Gemini key prefix → MUST NOT appear
+- [ ] Confirm only redacted indicators (e.g. `***`, `len=…`)

--- a/docs/qa-evidence/2026-04-30/T6.1-qr-pairing.md
+++ b/docs/qa-evidence/2026-04-30/T6.1-qr-pairing.md
@@ -1,0 +1,24 @@
+# T6.1 — QR Pairing Evidence
+
+**Status:** ⏳ Pending PM execution
+**Issue:** #68
+
+## Steps
+1. Open harness web UI on Mac (port from `03_HARNESS/.env`)
+2. Click "Generate QR"
+3. iPhone: Settings → Pair with harness → Scan QR
+4. Wait for "Paired ✓" on iPhone within 2 minutes
+5. Inspect harness log: device entry registered
+
+## AC
+- [ ] AC4: Pairing completes within 2 min
+- [ ] AC4: Both sides confirm — iPhone UI "Paired ✓" + harness log entry
+
+## Evidence
+- [ ] Screen recording iPhone scan flow: _link_
+- [ ] Harness log snippet showing device registration: _link_
+- [ ] App-side log: harnessState transitions Offline → Pairing → Online
+
+## Cross-device note
+
+Pair must also succeed on iPhone 15 Pro (demo device). Once paired pre-demo, **do NOT reset** the demo device after this test — backup 14 Pro retains the verified flow.

--- a/docs/qa-evidence/2026-04-30/T6.2-diag-convergence.md
+++ b/docs/qa-evidence/2026-04-30/T6.2-diag-convergence.md
@@ -1,0 +1,21 @@
+# T6.2 — Diagnostics Convergence (Scenario B)
+
+**Status:** ⏳ Pending PM execution
+**Issue:** #68
+
+## Steps
+1. Open in-app Diag panel
+2. Force scenario B per `docs/TEST_PLAN.md` T6.2
+3. Wait up to 30 seconds
+4. Confirm all checks turn green
+
+## AC
+- [ ] AC5: Scenario B convergence — all checks green within 30s
+
+## Evidence
+- [ ] Screenshot diag panel — all green: _link_
+- [ ] Timer shown — convergence ≤ 30s: _link_
+- [ ] App log fragment showing convergence event: _link_
+
+## Failure rule
+T6.2 fail = stop demo. Mandatory for release.


### PR DESCRIPTION
Closes #68

## What
4 evidence-packet skeletons under docs/qa-evidence/2026-04-30/ for the cold-start QA gate:
- T1.1 onboarding cold-start
- T1.2 Groq + T1.3 Gemini API keys
- T6.1 QR pairing iPhone↔harness
- T6.2 Diag convergence scenario B

Each file lists pre-conditions, steps, ACs and evidence slots PM fills during execution.

## Why
Sub #17·5/7 is QA execution work — code-only PR can't satisfy it. This PR ships the evidence framework so PM execution becomes mechanical (fill slots, attach screen recordings).

## Test plan
- [ ] PM executes T1.1-T1.3 + T6.1-T6.2 on iPhone 14 Pro backup, fills evidence files
- [ ] AC1-AC6 marked true after execution
- [ ] Sign-off comment from PM closes issue

⚠️ AC pending PM physical-device execution — review-only PR

Implementato da PM in batch session