### PR TITLE
docs(qa): H1-H3 + edge empty speech evidence skeletons

### DIFF
--- a/docs/qa-evidence/2026-04-30/H1-harness-offline-fallback.md
+++ b/docs/qa-evidence/2026-04-30/H1-harness-offline-fallback.md
@@ -1,0 +1,28 @@
+# H1 — Harness Offline + Fallback Gemini
+
+**Status:** ⏳ Pending PM execution
+**Issue:** #69 (Sub #17 · 6/7)
+
+## Setup
+- Active session iPhone, harness running on Mac, fallback Gemini enabled in Settings
+
+## Steps
+1. Start a normal voice session
+2. Fede kills harness (Ctrl+C)
+3. iPhone wake + "che ore sono?" (or any time-of-day style query)
+4. Observe: offline banner on pill, Gemini local fallback responds within 8s
+5. Restart harness — recovery should be automatic
+
+## AC
+- [ ] AC1: offline banner visible
+- [ ] AC1: Gemini fallback answers within 8s
+- [ ] AC1: harness recovery automatic on restart
+
+## Evidence
+- [ ] Screen recording iPhone: _link_
+- [ ] Harness log (kill + restart): _link_
+- [ ] App log (filter harnessState + speechLifecycle): _link_
+- [ ] Recovery timer in seconds: _to be filled_
+
+## Note
+H1 fail = demo a rischio se Wi-Fi event flaky.

--- a/docs/qa-evidence/2026-04-30/H2-harness-offline-no-fallback.md
+++ b/docs/qa-evidence/2026-04-30/H2-harness-offline-no-fallback.md
@@ -1,0 +1,25 @@
+# H2 — Harness Offline + Fallback Disabled
+
+**Status:** ⏳ Pending PM execution
+**Issue:** #69
+
+## Setup
+- Settings → toggle Gemini fallback OFF
+- Kill harness on Mac
+
+## Steps
+1. iPhone wake + a tool-dependent query (e.g. "send a WhatsApp to Fede")
+2. Observe: clean user-facing failure ("Servizio non disponibile, riprova" or eq.)
+3. Confirm NO crash, NO `mDataByteSize (0)` buffer-empty error in log
+
+## AC
+- [ ] AC2: clean error message displayed
+- [ ] AC2: no crash
+- [ ] AC2: no buffer-empty error in app log
+
+## Failure rule
+Any crash here = release blocker P0.
+
+## Evidence
+- [ ] Screen recording: _link_
+- [ ] App log filtered: _link_

--- a/docs/qa-evidence/2026-04-30/H3-harness-unpaired.md
+++ b/docs/qa-evidence/2026-04-30/H3-harness-unpaired.md
@@ -1,0 +1,20 @@
+# H3 — Harness Unpaired (Cold Device)
+
+**Status:** ⏳ Pending PM execution
+**Issue:** #69
+
+## Setup
+- iPhone 14 Pro backup device, NOT yet paired to harness
+
+## Steps
+1. Wake + any voice command
+2. Observe: UI prompt ("Pair your harness" or equivalent)
+3. Confirm no crash
+
+## AC
+- [ ] AC3: UI prompt for pairing visible
+- [ ] AC3: no crash
+
+## Evidence
+- [ ] Screen recording: _link_
+- [ ] App log: _link_

--- a/docs/qa-evidence/2026-04-30/edge-empty-speech.md
+++ b/docs/qa-evidence/2026-04-30/edge-empty-speech.md
@@ -1,0 +1,22 @@
+# Edge T10.3 — Empty Speech / Silence Post-Wake
+
+**Status:** ⏳ Pending PM execution
+**Issue:** #69
+
+## Steps
+1. Wake "Hey GIGI"
+2. Stay silent for 6 seconds (VAD timeout) OR force STT to return empty string
+3. Observe: pill transitions directly to .done
+
+## AC
+- [ ] AC4: pill .done without errors
+- [ ] AC4: log clean — NO `mDataByteSize (0)` audio error
+- [ ] AC4: `speech.didStart` not invoked with empty utterance
+
+## Evidence
+- [ ] Screen recording: _link_
+- [ ] App log filter `speechLifecycle`: _link_
+
+## Reference
+- DEBUG_DI_ANALYSIS.md item C
+- TEST_PLAN.md T10.3


### PR DESCRIPTION
Closes #69

## What
4 evidence-packet skeletons under docs/qa-evidence/2026-04-30/ for resilience scenarios:
- H1 harness offline + Gemini fallback enabled
- H2 harness offline + fallback disabled (clean failure)
- H3 harness unpaired cold device
- Edge empty speech / 6s silence post-wake

## Test plan
- [ ] PM coordinates Fede (Mac) ↔ Leo (iPhone) for H1+H2 execution
- [ ] PM executes H3 on backup 14 Pro
- [ ] PM executes edge empty-speech on demo device

⚠️ AC pending PM physical-device execution

Implementato da PM in batch session