### PR TITLE
fix(ios): Control Center toggle uses AppIntent + UserDefaults handshake

### DIFF
--- a/02_GIGI_APP/GIGI/GIGIApp.swift
+++ b/02_GIGI_APP/GIGI/GIGIApp.swift
@@ -88,10 +88,7 @@ struct GIGIApp: App {
                 .onOpenURL { url in
                     if url.scheme?.lowercased() == "gigi" {
                         if url.host == "listen" {
-                            if !PresenceSessionController.shared.isActive {
-                                PresenceSessionController.shared.startSession()
-                            }
-                            GigiSmartOrchestrator.shared.startListening()
+                            startListenFromControl()
                             return
                         }
                         NotificationCenter.default.post(name: .gigiGatewayCallback, object: url)
@@ -99,6 +96,35 @@ struct GIGIApp: App {
                     }
                     _ = GIDSignIn.sharedInstance.handle(url)
                 }
+                .onChange(of: scenePhase) { _, phase in
+                    if phase == .active { handlePendingControlListenIfAny() }
+                }
         }
+    }
+
+    // MARK: - Control Center toggle handshake (#159)
+
+    private func startListenFromControl() {
+        if !PresenceSessionController.shared.isActive {
+            PresenceSessionController.shared.startSession()
+        }
+        GigiSmartOrchestrator.shared.startListening()
+    }
+
+    /// Picks up the UserDefaults handshake set by `GIGIControlOpenIntent`
+    /// when the Control Center button taps. Without this, the AppIntent
+    /// foregrounds the app but no listening kicks in (the URL path used
+    /// to do that work).
+    private func handlePendingControlListenIfAny() {
+        let suite = UserDefaults(suiteName: "group.com.gigi.presence") ?? .standard
+        guard suite.bool(forKey: "pendingControlListenRequest") else { return }
+        let ts = suite.double(forKey: "pendingControlListenAt")
+        // 5s freshness window so a stale flag from a prior session does not
+        // accidentally start a listen on the next launch.
+        if Date().timeIntervalSince1970 - ts < 5 {
+            startListenFromControl()
+        }
+        suite.set(false, forKey: "pendingControlListenRequest")
+        suite.removeObject(forKey: "pendingControlListenAt")
     }
 }

--- a/02_GIGI_APP/GIGIWidget/GIGIWidgetControl.swift
+++ b/02_GIGI_APP/GIGIWidget/GIGIWidgetControl.swift
@@ -2,14 +2,38 @@ import AppIntents
 import SwiftUI
 import WidgetKit
 
+// MARK: - GIGIControlOpenIntent (#159)
+//
+// `OpenURLIntent` from a Control Center button does not always reach the host
+// app's onOpenURL handler when the app is suspended/terminated — iOS treats it
+// as an external URL handoff and silently drops it. Using a first-party
+// AppIntent with `openAppWhenRun = true` forces iOS to foreground the app
+// before invoking perform(), at which point we post the same NSNotification
+// the URL path used to post.
+
+@available(iOS 18.0, *)
+struct GIGIControlOpenIntent: AppIntent {
+    static var title: LocalizedStringResource = "Talk to GIGI"
+    static var description = IntentDescription("Open GIGI and start listening.")
+    static var openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        // Posting a darwin-wide notification is unreliable across the
+        // widget extension boundary, so we use a UserDefaults handshake
+        // GIGIApp picks up on launch.
+        let suite = UserDefaults(suiteName: "group.com.gigi.presence") ?? .standard
+        suite.set(true, forKey: "pendingControlListenRequest")
+        suite.set(Date().timeIntervalSince1970, forKey: "pendingControlListenAt")
+        return .result()
+    }
+}
+
 struct GIGIWidgetControl: ControlWidget {
     static let kind: String = "com.killsiri.GIGI.GIGIWidgetControl"
 
     var body: some ControlWidgetConfiguration {
-        StaticControlConfiguration(
-            kind: Self.kind
-        ) {
-            ControlWidgetButton(action: OpenURLIntent(URL(string: "gigi://listen")!)) {
+        StaticControlConfiguration(kind: Self.kind) {
+            ControlWidgetButton(action: GIGIControlOpenIntent()) {
                 Label("Talk to GIGI", systemImage: "mic.fill")
             }
         }


### PR DESCRIPTION
Closes #159

## Root cause
ControlWidgetButton with OpenURLIntent silently drops the URL on a suspended/terminated host app — iOS treats it as an external URL and never reaches GIGIApp.onOpenURL. Result: tap does nothing.

## Fix
- Replace OpenURLIntent with a first-party GIGIControlOpenIntent (openAppWhenRun = true) that writes a UserDefaults flag in the App Group
- GIGIApp listens for scenePhase == .active and consumes the flag (5s freshness window) to startListenFromControl()
- onOpenURL handler also routes through startListenFromControl() so the gigi://listen path is unchanged

## Test plan
- [ ] PM verifies AC#5 on iPhone 17 Pro: CC toggle → app foregrounds in listening
- [ ] Build verify pending

⚠️ AC pending PM verification
⚠️ Build verify SKIPPED

Implementato da PM in batch session