### PR TITLE
docs(demo): final demo duration decision — corta 3min50s

### DIFF
--- a/docs/DEMO_SCRIPT_duration.md
+++ b/docs/DEMO_SCRIPT_duration.md
@@ -1,0 +1,38 @@
+# Demo duration — final decision (Sub #74)
+
+> Append after the Plan B section from #73.
+
+## Demo duration — final decision
+
+| Variante | Durata | Scene | Pro | Contro |
+|---|---|---|---|---|
+| Corta | 3 min 50 s | 1–7 baseline | Energica · viewer attento · basso rischio failure cumulato | Poco approfondimento Scene 4–5 |
+| Estesa | 5–7 min | 1–7 + multi-turn Scene 2 + callback Scene 5 | Mostra ragionamento · "wow" più diluito | Più rischio fail cumulato · attenzione cala |
+
+## Decision
+
+**Corta — 3 min 50 s.**
+
+Rationale:
+
+1. The 1 May audience is investor-leaning, time-boxed, and prefers "punch + Q&A" over deep-dive.
+2. QA gate (#17) measured Scene 2 multi-turn at ~70 % reliability on real device — adding more turns multiplies the failure surface.
+3. The cumulative failure probability across 7 scenes is acceptable at the corta budget; the estesa adds 2 extra fail points for marginal narrative gain.
+4. Plan B for the corta is fully rehearsed; the estesa would need a second rehearsal pass we do not have time for.
+
+## Time budget after decision
+
+Total target: **3 min 50 s** (matches the storyboard from #71, no expansion beats).
+
+## Cuttable scenes (live overflow plan)
+
+If at runtime the presenter is at minute 3:00 and only at Scene 5, drop in this order:
+
+1. Scene 4 (use preferences) — narrative redundancy with Scene 5.
+2. Scene 3 (extract tasks) — visible from the overlay anyway during Scene 2.
+
+**Never cut:** Scene 1 (activate), Scene 6 (Better-Siri action), Scene 7 (permission boundary). These three carry the core differentiation message.
+
+## Rehearsal stopwatch
+
+PM runs the corta variant end-to-end with stopwatch T-1 day. Acceptance: ±20 % of target → 3 min 04 s to 4 min 36 s. Outside that → re-tighten cues.


### PR DESCRIPTION
Closes #74

Decision: corta variant (3 min 50 s, 7 scenes baseline). Rationale in doc.

⚠️ AC pending PM review

Implementato da PM in batch session