### PR TITLE
fix(ios): register GIGIWidgetControl in WidgetBundle + target membership (Closes #197)

### DIFF
--- a/02_GIGI_APP/GIGI.xcodeproj/project.pbxproj
+++ b/02_GIGI_APP/GIGI.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				GigiLiveActivityWidget.swift,
+				GIGIWidgetControl.swift,
 			);
 			target = 4E4F378E2F898626005EC9B5 /* GIGI */;
 		};
@@ -80,7 +81,6 @@
 			membershipExceptions = (
 				AppIntent.swift,
 				GIGIWidget.swift,
-				GIGIWidgetControl.swift,
 				Info.plist,
 			);
 			target = E0D953023C4404E8BCF0FFEC /* GIGIWidgetExtension */;

--- a/02_GIGI_APP/GIGIWidget/GIGIWidgetBundle.swift
+++ b/02_GIGI_APP/GIGIWidget/GIGIWidgetBundle.swift
@@ -10,7 +10,11 @@ import SwiftUI
 
 @main
 struct GIGIWidgetBundle: WidgetBundle {
+    @WidgetBundleBuilder
     var body: some Widget {
         GigiLiveActivityWidget()
+        if #available(iOS 18.0, *) {
+            GIGIWidgetControl()
+        }
     }
 }


### PR DESCRIPTION
Closes #197.

Hot-fix landing on top of merged PR #186. PR #186 added the `GIGIWidgetControl` ControlWidget but missed two project-config steps, leaving the Control Center toggle invisible in iOS 18.

## What

1. **`GIGIWidgetBundle.swift`** — `@main` bundle now exposes `GIGIWidgetControl()` inside `if #available(iOS 18.0, *)`. Uses `@WidgetBundleBuilder` so the conditional compiles cleanly.
2. **`project.pbxproj`** — corrects target membership of `GIGIWidgetControl.swift`:
   - Removed from `GIGIWidgetExtension` exceptions (was excluded from the target that actually needs it → bundle couldn't resolve the symbol).
   - Added to main `GIGI` target exceptions (it has no purpose in the main app binary).

## Verification

PM tested on real device 2026-05-04 against `test/test-cluster-fhi-pre-merge` build that already had this fix:

> "ok ora si vede talk to gigi nel control"

Tap on the control → app foregrounds + Dynamic Island descends to `.listening` as designed in PR #186 / issue #159.

## Test plan

- [x] Compile-clean on `xcodebuild -allowProvisioningUpdates ... build` (BUILD SUCCEEDED, paid signed Mac, 2026-05-04 ~15:56)
- [x] PM on iPhone: "Talk to GIGI" present in Control Center add-control catalog
- [x] PM on iPhone: tap descends DI to `.listening`